### PR TITLE
Mention leapp-related EuroLinux presence

### DIFF
--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -348,7 +348,7 @@ msgstr "ما هي الانظمة التي تدعم الارتقاء؟"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 
 #: www/templates/elevate/index.html:177

--- a/locale/ca/LC_MESSAGES/django.po
+++ b/locale/ca/LC_MESSAGES/django.po
@@ -336,7 +336,7 @@ msgstr ""
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 
 #: www/templates/elevate/index.html:177

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -337,7 +337,7 @@ msgstr ""
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 
 #: www/templates/elevate/index.html:177

--- a/locale/da/LC_MESSAGES/django.po
+++ b/locale/da/LC_MESSAGES/django.po
@@ -336,7 +336,7 @@ msgstr ""
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 
 #: www/templates/elevate/index.html:177

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -366,7 +366,7 @@ msgstr "Welche Betriebssysteme unterstützt ELevate?"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 
 #: www/templates/elevate/index.html:177

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -340,7 +340,7 @@ msgstr ""
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 
 #: www/templates/elevate/index.html:177

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -377,11 +377,11 @@ msgstr "¿Cuáles sistemas operativos admite ELevate?"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 "Actualmente, ELevate brinda datos Leapp para migrar de CentOS 7 a los "
 "sistemas operativos siguientes: <ul> <li>AlmaLinux OS 8</li> <li>CentOS "
-"Stream 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"Stream 8</li> <li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 
 #: www/templates/elevate/index.html:177
 msgid "Will migration be \"in-place\"?"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -336,7 +336,7 @@ msgstr ""
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 
 #: www/templates/elevate/index.html:177

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -378,11 +378,11 @@ msgstr "Quels systèmes d'exploitation ELevate prend-il en charge ?"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 "Actuellement ELevate fournit des données Leapp pour la migration de CentOS 7 "
 "vers les OS suivants: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8<li></ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8<li></ul>"
 
 #: www/templates/elevate/index.html:177
 msgid "Will migration be \"in-place\"?"

--- a/locale/he/LC_MESSAGES/django.po
+++ b/locale/he/LC_MESSAGES/django.po
@@ -366,10 +366,10 @@ msgstr "באילו מערכת הפעלה תומכת ELevate?"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 "ELevate מספקת כיום נתוני Leapp להגירה מ־CentOS 7 למערכות ההפעלה הבאות: <ul> "
-"<li>AlmaLinux OS 8</li>‏ <li>CentOS Stream 8</li> ‏<li>Oracle Linux 8</li>‏ "
+"<li>AlmaLinux OS 8</li>‏ <li>CentOS Stream 8</li> ‏<li>EuroLinux 8</li>‏ <li>Oracle Linux 8</li>‏ "
 "<li>Rocky Linux 8</li> </ul>"
 
 #: www/templates/elevate/index.html:177

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -377,11 +377,11 @@ msgstr "Quali sistemi operativi supporta ELevate?"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 "Attualmente ELevate fornisce i dati Leapp per la migrazione da CentOS 7 ai "
 "seguenti sistemi operativi: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream "
-"8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"8</li> <li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 
 #: www/templates/elevate/index.html:177
 msgid "Will migration be \"in-place\"?"

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -371,10 +371,10 @@ msgstr "ELevate はどのような OS に対応していますか？"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 "現在、ELEVate は CentOS 7 から以下の OS へ移行するための Leapp データを提供し"
-"ています: <ul> <li>Alma Linux OS 8</li> <li>CentOS Stream 8</li> <li>Oracle "
+"ています: <ul> <li>Alma Linux OS 8</li> <li>CentOS Stream 8</li> <li>EuroLinux 8</li> <li>Oracle "
 "Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 
 #: www/templates/elevate/index.html:177

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -358,10 +358,10 @@ msgstr "ELevate가 지원하는 운영 체제는 무엇입니까?"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 "현재 ELevate는 CentOS 7에서 마이그레이션을 위한 Leapp 데이터를 제공합니다. "
-"OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> <li>Oracle Linux "
+"OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> <li>EuroLinux 8</li> <li>Oracle Linux "
 "8</li> <li>Rocky Linux 8</li> </ul>"
 
 #: www/templates/elevate/index.html:177

--- a/locale/lt/LC_MESSAGES/django.po
+++ b/locale/lt/LC_MESSAGES/django.po
@@ -338,7 +338,7 @@ msgstr ""
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 
 #: www/templates/elevate/index.html:177

--- a/locale/lv/LC_MESSAGES/django.po
+++ b/locale/lv/LC_MESSAGES/django.po
@@ -349,7 +349,7 @@ msgstr ""
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 
 #: www/templates/elevate/index.html:177

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -358,7 +358,7 @@ msgstr "Jakie systemy operacyjne wspiera ELevate?"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 
 #: www/templates/elevate/index.html:177

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -376,11 +376,11 @@ msgstr "Que sistemas operacionais o ELevate suporta?"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 "Atualmente, o ELevate fornece dados Leapp para migração do CentOS 7 para os "
 "seguintes sistemas operacionais: <ul> <li>AlmaLinux OS 8</li> <li>CentOS "
-"Stream 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"Stream 8</li> <li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 
 #: www/templates/elevate/index.html:177
 msgid "Will migration be \"in-place\"?"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -378,11 +378,11 @@ msgstr "Que sistemas operacionais o ELevate suporta?"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 "Atualmente, o ELevate fornece dados Leapp para migração do CentOS 7 para os "
 "seguintes sistemas operacionais: <ul> <li>AlmaLinux OS 8</li> <li>CentOS "
-"Stream 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"Stream 8</li> <li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 
 #: www/templates/elevate/index.html:177
 msgid "Will migration be \"in-place\"?"

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -351,11 +351,11 @@ msgstr "Какие операционные системы поддержива�
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 "В настоящее время ELevate предоставляет данные Leapp для миграции с CentOS 7 "
 "на следующие ОС: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 
 #: www/templates/elevate/index.html:177
 msgid "Will migration be \"in-place\"?"

--- a/locale/sk/LC_MESSAGES/django.po
+++ b/locale/sk/LC_MESSAGES/django.po
@@ -374,11 +374,11 @@ msgstr "Aké operačné systémy podporuje ELevate?"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 "V súčasnosti ELevate poskytuje údaje Leapp na migráciu z CentOS 7 na "
 "nasledujúce OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 
 #: www/templates/elevate/index.html:177
 msgid "Will migration be \"in-place\"?"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -347,11 +347,11 @@ msgstr "Vilka operativsystem stöder ELevate?"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 "För närvarande tillhandahåller ELevate Leapp data för migrering från CentOS "
 "7 till följande OS: <ul><li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li></ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li></ul>"
 
 #: www/templates/elevate/index.html:177
 msgid "Will migration be \"in-place\"?"

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -374,11 +374,11 @@ msgstr "ELevate hangi işletim sistemlerini destekliyor?"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 "Şu anda ELevate, CentOS 7'den aşağıdaki işletim sistemlerine geçiş için "
 "Leapp verileri sağlamaktadır: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream "
-"8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"8</li> <li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 
 #: www/templates/elevate/index.html:177
 msgid "Will migration be \"in-place\"?"

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -378,10 +378,10 @@ msgstr "Які операційні системи підтримує ELevate?"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 "Наразі ELevate надає дані Leapp для міграції з CentOS 7 до таких ОС: <ul> "
-"<li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> <li>Oracle Linux 8</li> "
+"<li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> <li>EuroLinux 8</li> <li>Oracle Linux 8</li> "
 "<li>Rocky Linux 8</li> </ul>"
 
 #: www/templates/elevate/index.html:177

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -359,10 +359,10 @@ msgstr "EL易升支持哪些操作系统？"
 msgid ""
 "Currently ELevate provides Leapp data for migration from CentOS 7 to the "
 "following OS: <ul> <li>AlmaLinux OS 8</li> <li>CentOS Stream 8</li> "
-"<li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
+"<li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux 8</li> </ul>"
 msgstr ""
 "目前，EL易升提供Leapp数据以从CentOS7迁移到下列操作系统： <ul> <li>AlmaLinux "
-"OS 8</li> <li>CentOS Stream 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux "
+"OS 8</li> <li>CentOS Stream 8</li> <li>EuroLinux 8</li> <li>Oracle Linux 8</li> <li>Rocky Linux "
 "8</li> </ul>"
 
 #: www/templates/elevate/index.html:177

--- a/www/templates/elevate/index.html
+++ b/www/templates/elevate/index.html
@@ -165,6 +165,7 @@
                             <ul>
                                 <li>AlmaLinux OS 8</li>
                                 <li>CentOS Stream 8</li>
+                                <li>EuroLinux 8</li>
                                 <li>Oracle Linux 8</li>
                                 <li>Rocky Linux 8</li>
                             </ul>


### PR DESCRIPTION
Since [a former PR](https://github.com/AlmaLinux/leapp-data/pull/6) has been accepted, I added appropriate mentions to the website.