### PR TITLE
Set sticky header shrink by default

### DIFF
--- a/www/templates/_partial/navbar.html
+++ b/www/templates/_partial/navbar.html
@@ -21,7 +21,7 @@
   }
   .announcement {
     width:100%;
-    height: 400px;
+    height: 100px;
     background:url("{% static 'images/screen-banner.png' %}") #0E2236;
     background-position:top;
     background-repeat:no-repeat;
@@ -32,7 +32,7 @@
   @media only screen and (min-width:2560px) {
     .announcement {
       width:100%;
-      height: 400px;
+      height: 100px;
       background:url("{% static 'images/wide-screen.png' %}");
       background-position:top;
     }
@@ -93,15 +93,15 @@
       right:50px;
       top:15px;
       z-index:1;
-      background:url("{% static 'images/up-arrow.png' %}") #fff;
+      background:url("{% static 'images/down-arrow.png' %}") #fff;
       border-radius:100px;
       cursor:pointer;
   }
   .chk:checked + .chk-label span {
-      background:url("{% static 'images/down-arrow.png' %}") #fff;
+      background:url("{% static 'images/up-arrow.png' %}") #fff;
   }
   .chk:checked ~ .sticky-link .announcement {
-    height:100px;
+    height:400px;
   }
   #chk-close {
       display:none;


### PR DESCRIPTION
The header is not expanded by default. It opens shrink, and the user can expand it by clicking on the relevant button.