### PR TITLE
Add matomo tracking code

### DIFF
--- a/www/templates/layouts/base.html
+++ b/www/templates/layouts/base.html
@@ -97,6 +97,23 @@
         gtag('config', 'G-1C1KF63NYM');
     </script>
 {% endif %}
+<!-- Matomo -->
+<!-- "do not track" settings are honored -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://matomo.almalinux.org/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '1']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+
 
 <script>
     let sticky = document.querySelector(".sticky");


### PR DESCRIPTION
Add matomo tracking code in preparation of dropping google analytics.

It is outside of the "dnt_is_enabled" block because Matomo itself respects the DNT flag.