### PR TITLE
Remove publish date from subpages as it's unnecessary

### DIFF
--- a/layouts/p/single.html
+++ b/layouts/p/single.html
@@ -11,14 +11,7 @@
             <h1 class="al-section-title mb-4">{{ .Title }}</h1>
             <article>
                 <div class="al-page-content pb-5 al-wysiwyg">
-
                     {{ .Content }}
-                </div>
-                <div class="al-page-date d-flex align-items-center"
-                     title="Date Published"
-                     dir="ltr">
-                    <i class="bi bi-calendar pe-1"></i>
-                    <span>{{ .PublishDate}}</span>
                 </div>
             </article>
         </div>


### PR DESCRIPTION
This was defaulting to `0001-01-01 00:00:00 +0000 UTC` as no `date` was in the front matter. Looking at all of the pages that use this template none require a publish date.

EX: https://almalinux.org/p/legal-notice/ vs. https://remove-publish-date-subpages.almalinux-org.pages.dev/p/legal-notice/