### PR TITLE
adding OpenLogic logo again

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -376,14 +376,19 @@
                 <h2 class="pb-2 mb-5 text-center border-bottom">
                     {{ i18n "Commercial Support" }}
                 </h2>
+   			 <!-- Tuxcare -->
                 <div class="row row-cols-2 row-cols-sm-4 row-cols-md-6 g-5 al-commercial-supporter-list">
-
                         <a href="https://tuxcare.com/linux-support-services/">
                             <div class="col d-flex flex-fill align-items-center justify-content-center al-commercial-supporter-logo-container">
                                 <img loading="lazy" src="/brands/TuxCare_2.svg" alt="TuxCare" class="al-commercial-supporter-logo">
                             </div>
                         </a>
-
+   			 <!-- OpenLogic -->
+                        <a href="https://www.openlogic.com/">
+                            <div class="col d-flex flex-fill align-items-center justify-content-center al-commercial-supporter-logo-container">
+                                <img loading="lazy" src="/brands/logo-openlogic-tagline-white.svg" alt="OpenLogic" class="al-commercial-supporter-logo">
+                            </div>
+                        </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
It looks like the OpenLogic logo under commercial support got lost. Adding it back in. 