### PR TITLE
Fixes Page Content Overflowing on Blog on Small Displays

### DIFF
--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -357,10 +357,6 @@ border-bottom-color: #14598a !important;
   padding: 3rem 15px !important;
 }
 @media (max-width: 800px){
-  .img-fluid, .img-thumbnail {
-    height: auto;
-    max-width: 100%;
-  }
   .custom-blog-page-section {
     max-width: 100%;
     margin: auto;

--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -356,6 +356,16 @@ border-bottom-color: #14598a !important;
 .al-page-blog-post .container{
   padding: 3rem 15px !important;
 }
+@media (max-width: 800px){
+  .img-fluid, .img-thumbnail {
+    height: auto;
+    max-width: 100%;
+  }
+  .custom-blog-page-section {
+    max-width: 100%;
+    margin: auto;
+  }
+}
 .al-page-elevate-index .al-cta-discuss {
   background: #2891ff;
   color: #222;

--- a/assets/scss/blog.css
+++ b/assets/scss/blog.css
@@ -153,11 +153,8 @@
   color: #000 !important;
 }
 @media (max-width: 800px){
-  .img-fluid, .img-thumbnail {
-    height: auto;
-    max-width: 100%;
-  }
   .custom-blog-page-section {
     max-width: 100%;
     margin: auto;
-  }/*# sourceMappingURL=blog.css.map */
+  }
+}/*# sourceMappingURL=blog.css.map */

--- a/assets/scss/blog.css
+++ b/assets/scss/blog.css
@@ -151,4 +151,13 @@
 
 .pagination .disabled {
   color: #000 !important;
-}/*# sourceMappingURL=blog.css.map */
+}
+@media (max-width: 800px){
+  .img-fluid, .img-thumbnail {
+    height: auto;
+    max-width: 100%;
+  }
+  .custom-blog-page-section {
+    max-width: 100%;
+    margin: auto;
+  }/*# sourceMappingURL=blog.css.map */

--- a/assets/scss/blog.scss
+++ b/assets/scss/blog.scss
@@ -206,4 +206,13 @@
   color: #000 !important;
   
 }
-
+@media (max-width: 800px){
+  .img-fluid, .img-thumbnail {
+    height: auto;
+    max-width: 100%;
+  }
+  .custom-blog-page-section {
+    max-width: 100%;
+    margin: auto;
+  }
+}

--- a/assets/scss/blog.scss
+++ b/assets/scss/blog.scss
@@ -207,10 +207,6 @@
   
 }
 @media (max-width: 800px){
-  .img-fluid, .img-thumbnail {
-    height: auto;
-    max-width: 100%;
-  }
   .custom-blog-page-section {
     max-width: 100%;
     margin: auto;

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,19 +1,4 @@
 {{ define "main" }}
-<style>
-    @media (max-width: 800px){
-
-        .img-fluid, .img-thumbnail {
-  height: auto;
-  max-width: 100%;
-}
-.custom-blog-page-section {
-  width: 450px;
-  margin: auto;
-}
-
-}
-</style>
-
 <div class="al-body-container" >
 
     <ol class="post-list pl-0">


### PR DESCRIPTION
I tested https://www.almalinux.com/blog on an iPhone 12 pro and a Samsung S20, and the content is wider than the screen.

The cause was the inline CSS in the /layouts/blog/list.html

I moved the CSS into the CSS files and changed

width: 450px;

to

max-width: 100%;

This will prevent page overflow on devices with > 800px wide displays.