### PR TITLE
Changes Margin of "Resources" Drop Down

### DIFF
--- a/layouts/partials/common/nav.html
+++ b/layouts/partials/common/nav.html
@@ -33,7 +33,7 @@
                     </a>
                 </li>
                 <li class="nav-item dropdown ">
-                    <a class="nav-link dropdown-toggle " id="navbarDropResources" data-toggle="dropdown" aria-expanded="false" style="margin-top:3px">
+                    <a class="nav-link dropdown-toggle " id="navbarDropResources" data-toggle="dropdown" aria-expanded="false" style="margin-top:5px">
                         {{ i18n "Resources" }}
                     </a>
 


### PR DESCRIPTION
For some reason the a element for .dropdown-toggle had it's top margin set to 3px, while all the other menu items had theirs set to 5px.

I updated this to make it 5px across the board so that the top menu would line up on desktop browsers.

Previous:
![250069686-7ff59d1e-bf87-494c-9379-b9d2b4a22bc0](https://github.com/AlmaLinux/almalinux.org/assets/10442336/bdbb2ad2-92d8-4ccf-bcf1-f37136a7e064)
Updated:
![updated](https://github.com/AlmaLinux/almalinux.org/assets/10442336/3fa738e6-f7d2-4710-b9a2-b0c2238c4a64)
