### PR TITLE
Use GH CI for deployment

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,6 +1,6 @@
 on:
-  push:
-    branches: master
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
   publish:
@@ -28,12 +28,6 @@ jobs:
       - name: Build
         run: hugo --minify
 
-      # this is needed to trick CF into deploying to production
-      # can probably be removed where there is a solution to
-      # https://github.com/cloudflare/pages-action/issues/63
-      - name: remove git dir
-        run: rm -rf .git
-
       - name: move redirects file into place
         run: cp _redirects public/
 
@@ -44,4 +38,4 @@ jobs:
           accountId: b2eab8b024e2fc0155a48c4fc7115e64
           #projectName: almalinux
           projectName: almalinux-ci-test
-          directory: public
+          directory:  public

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -36,5 +36,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: b2eab8b024e2fc0155a48c4fc7115e64
-          projectName: almalinux-ci-test
+          projectName: almalinux
           directory:  public

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
-    name: Publish to Cloudflare Pages
+    name: Publish Preview to Cloudflare Pages
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, synchronize]
 
 jobs:
   publish:

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -36,5 +36,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: b2eab8b024e2fc0155a48c4fc7115e64
-          projectName: almalinux
+          projectName: almalinux-org
           directory:  public

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 jobs:

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, edited]
 
 jobs:
   publish:

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -36,6 +36,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: b2eab8b024e2fc0155a48c4fc7115e64
-          #projectName: almalinux
           projectName: almalinux-ci-test
           directory:  public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,3 @@
-# pip3 install PyYAML && python3 find_missing_i18n_strings.py && python3 setup-pages-for-supported-languages.py && hugo --minify && cp _redirects public/_redirects
-
 on:
   push:
     branches: master
@@ -35,6 +33,48 @@ jobs:
       # https://github.com/cloudflare/pages-action/issues/63
       - name: remove git dir
         run: rm -rf .git
+
+      - name: move redirects file into place
+        run: cp _redirects public/
+
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: b2eab8b024e2fc0155a48c4fc7115e64
+          #projectName: almalinux
+          projectName: almalinux-ci-test
+          directory:  public
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    name: Publish to Cloudflare Pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Check for missing base language strings
+        run: python3 find_missing_i18n_strings.py
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+          # extended: true
+
+      - name: Generate language files
+        run: python3 setup-pages-for-supported-languages.py
+
+      - name: Build
+        run: hugo --minify
 
       - name: move redirects file into place
         run: cp _redirects public/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+on:
+  push:
+    branches: production
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    name: Publish to Cloudflare Pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Check for missing base language strings
+        run: python3 find_missing_i18n_strings.py
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+          # extended: true
+
+      - name: Generate language files
+        run: python3 setup-pages-for-supported-languages.py
+
+      - name: Build
+        run: hugo --minify
+
+      # this is needed to trick CF into deploying to production
+      # can probably be removed where there is a solution to
+      # https://github.com/cloudflare/pages-action/issues/63
+      - name: remove git dir
+        run: rm -rf .git
+
+      - name: move redirects file into place
+        run: cp _redirects public/
+
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: b2eab8b024e2fc0155a48c4fc7115e64
+          projectName: almalinux
+          directory: public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: b2eab8b024e2fc0155a48c4fc7115e64
-          #projectName: almalinux
-          projectName: almalinux-ci-test
+          projectName: almalinux
           directory: public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
+# pip3 install PyYAML && python3 find_missing_i18n_strings.py && python3 setup-pages-for-supported-languages.py && hugo --minify && cp _redirects public/_redirects
+
 on:
   push:
-    branches: production
+    branches: master
 
 jobs:
   publish:
@@ -42,5 +44,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: b2eab8b024e2fc0155a48c4fc7115e64
-          projectName: almalinux
+          #projectName: almalinux
+          projectName: almalinux-ci-test
           directory: public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,4 +46,4 @@ jobs:
           accountId: b2eab8b024e2fc0155a48c4fc7115e64
           #projectName: almalinux
           projectName: almalinux-ci-test
-          directory: public
+          directory:  public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,5 +42,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: b2eab8b024e2fc0155a48c4fc7115e64
-          projectName: almalinux
+          projectName: almalinux-org
           directory: public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,4 @@
+---
 on:
   push:
     branches: master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
           accountId: b2eab8b024e2fc0155a48c4fc7115e64
           #projectName: almalinux
           projectName: almalinux-ci-test
-          directory:  public
+          directory: public
 
 on:
   pull_request:


### PR DESCRIPTION
This makes it easier to approve CI runs on PRs from forks which will create preview URLs.