### PR TITLE
Use relative localized URLs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -4,3 +4,5 @@
 /feed/ /blog/index.xml 301
 /certified/amd-ryzen-may2022 /amd-ryzen-may2022 301
 /certified/amd-ryzen-may2022/ /amd-ryzen-may2022 301
+/discord https://discord.com/invite/juVTqYFVJB 301
+/discord/ https://discord.com/invite/juVTqYFVJB 301

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -70,7 +70,7 @@
                         {{ i18n "An Open Source, community owned and governed, forever-free enterprise Linux distribution, focused on long-term stability, providing a robust production-grade platform. AlmaLinux OS is ABI compatible with RHEL®." }}
                     </p>
                     <div class="d-grid gap-3 d-md-flex justify-content-md-start pt-3">
-                        <a href="{{ "/contribute" | absLangURL }}" class="btn btn-lg px-4 me-md-2 al-hero-cta-primary">
+                        <a href="{{ "/contribute" | relLangURL }}" class="btn btn-lg px-4 me-md-2 al-hero-cta-primary">
                             <i class="bi bi-people pe-1"></i>
                             {{ i18n "Contribute" }}
                         </a>

--- a/layouts/partials/common/footer.html
+++ b/layouts/partials/common/footer.html
@@ -13,8 +13,8 @@
                     <li><a href="https://bugs.almalinux.org/">{{ i18n "Bugs" }}</a></li>
                     <li><a href="https://repo.almalinux.org/">{{ i18n "Repository" }}</a></li>
                     <li><a href="/#downloads">{{ i18n "Downloads" }}</a></li>
-                    <li><a href="{{ "/members" | absLangURL }}">{{ i18n "Membership" }}</a></li>
-                    <li><a href="{{ "/elevate" | absLangURL }}">ELevate</a></li>
+                    <li><a href="{{ "/members" | relLangURL }}">{{ i18n "Membership" }}</a></li>
+                    <li><a href="{{ "/elevate" | relLangURL }}">ELevate</a></li>
                     <li><a href="https://lists.almalinux.org/">{{ i18n "Mailing Lists" }}</a></li>
                     <li><a href="https://status.almalinux.org/">{{ i18n "Status Page" }}</a></li>
                 </ul>
@@ -35,26 +35,26 @@
             <div class="col-6 col-md">
                 <h5>Legal</h5>
                 <ul class="list-unstyled">
-                    <li><a href="{{ "/p/legal-notice/" | absLangURL }}">{{ i18n "Legal Notice" }}</a></li>
-                    <li><a href="{{ "/p/privacy-policy/" | absLangURL }}">{{ i18n "Privacy Policy" }}</a></li>
-                    <li><a href="{{ "/p/terms-of-service/" | absLangURL }}">{{ i18n "Terms of Service" }}</a></li>
+                    <li><a href="{{ "/p/legal-notice/" | relLangURL }}">{{ i18n "Legal Notice" }}</a></li>
+                    <li><a href="{{ "/p/privacy-policy/" | relLangURL }}">{{ i18n "Privacy Policy" }}</a></li>
+                    <li><a href="{{ "/p/terms-of-service/" | relLangURL }}">{{ i18n "Terms of Service" }}</a></li>
                     <li>
-                        <a href="{{ "/p/the-almalinux-os-licensing-policy/" | absLangURL }}">
+                        <a href="{{ "/p/the-almalinux-os-licensing-policy/" | relLangURL }}">
                             {{ i18n "Licensing Policy" }}
                         </a>
                     </li>
                     <li>
-                        <a href="{{ "/p/the-almalinux-os-trademark-usage-policy/" | absLangURL }}">
+                        <a href="{{ "/p/the-almalinux-os-trademark-usage-policy/" | relLangURL }}">
                             {{ i18n "Trademark Usage Policy" }}
                         </a>
                     </li>
                     <li>
-                        <a href="{{ "/p/foundation-bylaws/" | absLangURL }}">
+                        <a href="{{ "/p/foundation-bylaws/" | relLangURL }}">
                             {{ i18n "Foundation Bylaws" }}
                         </a>
                     </li>
                     <li>
-                        <a href="{{ "/p/membership-committee/" | absLangURL }}">
+                        <a href="{{ "/p/membership-committee/" | relLangURL }}">
                             {{ i18n "Membership Committee" }}
                         </a>
                     </li>

--- a/layouts/partials/common/nav.html
+++ b/layouts/partials/common/nav.html
@@ -23,7 +23,7 @@
         <div class="collapse navbar-collapse justify-content-end" id="main-navbar">
             <ul class="navbar-nav  mb-2 mb-lg-0">
                 <li class="nav-item">
-                    <a class="nav-link" href="{{ "/blog" | absLangURL }}" style="margin-top:5px">
+                    <a class="nav-link" href="{{ "/blog" | relLangURL }}" style="margin-top:5px">
                         {{ i18n "Blog" }}
                     </a>
                 </li>
@@ -50,12 +50,12 @@
                             </a>
                         </li>
                         <li>
-                            <a class="dropdown-item" href="{{ "/members" | absLangURL }}" style="color:aliceblue">
+                            <a class="dropdown-item" href="{{ "/members" | relLangURL }}" style="color:aliceblue">
                                 {{ i18n "Membership" }}
                             </a>
                         </li>
                         <li>
-                            <a class="dropdown-item" href="{{ "/elevate" | absLangURL }}" style="color:aliceblue">
+                            <a class="dropdown-item" href="{{ "/elevate" | relLangURL }}" style="color:aliceblue">
                                 ELevate
                             </a>
                         </li>
@@ -107,6 +107,6 @@
 <div id="al-motd" dir="ltr" data-nosnippet="" style="display: block; letter-spacing: 0px;">
     <div class="container pl-3">
         <i class="bi bi-info-circle"></i>
-        <div class="text">{{ i18n "The Future of AlmaLinux is Bright - AlmaLinux OS Foundation's renewed commitment to our users." }} <a href="{{ "/blog/future-of-almalinux/" | absLangURL }}">{{ i18n "Read more" }}</a></div>
+        <div class="text">{{ i18n "The Future of AlmaLinux is Bright - AlmaLinux OS Foundation's renewed commitment to our users." }} <a href="{{ "/blog/future-of-almalinux/" | relLangURL }}">{{ i18n "Read more" }}</a></div>
     </div>
 </div>


### PR DESCRIPTION
This will make using the CF pages preview sites from CI easier since the links will all be relative and not send you to the live site by mistake.