### PR TITLE
Clean up blog syntax a bit, add code highlighting config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -46,3 +46,18 @@ markup:
     goldmark:
         renderer:
             unsafe: true
+    highlight:
+      anchorLineNos: false
+      codeFences: true
+      guessSyntax: false
+      hl_Lines: ""
+      hl_inline: false
+      lineAnchors: ""
+      lineNoStart: 1
+      lineNos: false
+      lineNumbersInTable: true
+      noClasses: true
+      noHl: false
+      style: github-dark
+      tabWidth: 4
+

--- a/content/blog/zenbleed-patch-call-for-testing.md
+++ b/content/blog/zenbleed-patch-call-for-testing.md
@@ -31,27 +31,35 @@ You can see the diff of the changes on [git.almalinux.org](https://git.almalinux
 
 Due to the risks involved in these patches, these packages are not yet in production and need testing! If you are willing to help provide us feedback, and have access to a **bare metal AMD system**, you can manually install them by pulling them from the AlmaLinux Build System.  
 
-To install the new RPM on AlmaLinux 8: 
+**To install the new RPM on AlmaLinux 8:**
 
-`dnf update https://build.almalinux.org/pulp/content/builds/AlmaLinux-8-x86_64-7032-br/Packages/l/linux-firmware-20230404-114.git2e92a49f.el8_8.alma.noarch.rpm`
+{{< highlight bash >}}
+dnf update https://build.almalinux.org/pulp/content/builds/AlmaLinux-8-x86_64-7032-br/Packages/l/linux-firmware-20230404-114.git2e92a49f.el8_8.alma.noarch.rpm
+{{< /highlight >}}
 
-For AlmaLinux 9:
+**For AlmaLinux 9:**
 
-`dnf update https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-x86_64-7033-br/Packages/l/linux-firmware-20230310-134.el9_2.alma.noarch.rpm`
+{{< highlight bash >}}
+dnf update https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-x86_64-7033-br/Packages/l/linux-firmware-20230310-134.el9_2.alma.noarch.rpm
+{{< /highlight >}}
 
+**To check that the installation completed successfully, you can run:**
 
-To check that the installation completed successfully, you can run `rpm -qa linux-firmware`. 
+{{< highlight bash >}}
+rpm -qa linux-firmware
+{{< /highlight >}}
 
 **To update CPU microcode run the following:**
-> echo 1 > /sys/devices/system/cpu/microcode/reload
+{{< highlight bash >}}
+echo 1 > /sys/devices/system/cpu/microcode/reload
+{{< /highlight >}}
 
-Once you have completed your testing, please help us by letting us know it works for you! Please share the following information (sanitized in whatever way you feel comfortable) in a comment on the issue we’ve opened to track this update on bugs.almalinux.org. We have created one specific to [AlmaLinux 8](https://bugs.almalinux.org/view.php?id=412) and one for [AlmaLinux 9](https://bugs.almalinux.org/view.php?id=413). Please include the output of the two commands from the test server.
+Once you have completed your testing, please help us by letting us know it works for you! Please share the following information (sanitized in whatever way you feel comfortable) in a comment on the issue we’ve opened to track this update on bugs.almalinux.org. We have created one specific to [AlmaLinux 8](https://bugs.almalinux.org/view.php?id=412) and one for [AlmaLinux 9](https://bugs.almalinux.org/view.php?id=413). Please include the output of the two commands from the test server and if it worked for you.
 
-> Did it work for you? Yes or no.
-
-> lscpu
-
-> journalctl -k --grep=microcode
+{{< highlight bash >}}
+lscpu
+journalctl -k --grep=microcode
+{{< /highlight >}}
 
 
 ## Why call for testing now?


### PR DESCRIPTION
- Overflow on long commands, need to investigate why
- Fixed inconsistent bolding

While the style still need to be fixed, I think it's far cleaner than what's up currently. 

@mattlasheboro will be looking into the overflow issue tomorrow. I'll leave it up to someone else to decide if we want to merge this in as-is.

Example of what this change looks like:

![image](https://github.com/AlmaLinux/almalinux.org/assets/196810/5e684d44-7f09-49fa-963f-272a74464cb1)

Example of what it currently looks like:

<img width="1345" alt="image" src="https://github.com/AlmaLinux/almalinux.org/assets/196810/a42524d4-8392-4f47-9128-1ae4c74785d6">

