### PR TITLE
Enable and style code syntax highlighting, adjust AMD zenbleed blog post formatting

### DIFF
--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -852,5 +852,16 @@ a:hover{
   
 }
 
+.highlight > pre {
+  white-space: pre-wrap;
+  white-space: -moz-pre-wrap;
+  white-space: -pre-wrap;
+  white-space: -o-pre-wrap;
+  padding: 10px;
+  font-size: 16px;
+  border-radius: 10px;
+  overflow-wrap: anywhere;
+}
+
 
 /*# sourceMappingURL=bundle.css.map */

--- a/assets/scss/blog.css
+++ b/assets/scss/blog.css
@@ -156,4 +156,14 @@
     max-width: 100%;
     margin: auto;
   }
+.highlight > pre {
+  white-space: pre-wrap;
+  white-space: -moz-pre-wrap;
+  white-space: -pre-wrap;
+  white-space: -o-pre-wrap;
+  padding: 10px;
+  font-size: 16px;
+  border-radius: 10px;
+  overflow-wrap: anywhere;
+}
 }/*# sourceMappingURL=blog.css.map */

--- a/assets/scss/blog.scss
+++ b/assets/scss/blog.scss
@@ -210,4 +210,14 @@
     max-width: 100%;
     margin: auto;
   }
+.highlight > pre {
+  white-space: pre-wrap;
+  white-space: -moz-pre-wrap;
+  white-space: -pre-wrap;
+  white-space: -o-pre-wrap;
+  padding: 10px;
+  font-size: 16px;
+  border-radius: 10px;
+  overflow-wrap: anywhere;
+}
 }

--- a/content/blog/zenbleed-patch-call-for-testing.md
+++ b/content/blog/zenbleed-patch-call-for-testing.md
@@ -34,25 +34,35 @@ Due to the risks involved in these patches, these packages are not yet in produc
 
 To install the new RPM on AlmaLinux 8: 
 
-`dnf update https://build.almalinux.org/pulp/content/builds/AlmaLinux-8-x86_64-7032-br/Packages/l/linux-firmware-20230404-114.git2e92a49f.el8_8.alma.noarch.rpm`
+{{< highlight bash >}}
+dnf update https://build.almalinux.org/pulp/content/builds/AlmaLinux-8-x86_64-7032-br/Packages/l/linux-firmware-20230404-114.git2e92a49f.el8_8.alma.noarch.rpm
+{{< /highlight >}}
 
 For AlmaLinux 9:
 
-`dnf update https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-x86_64-7033-br/Packages/l/linux-firmware-20230310-134.el9_2.alma.noarch.rpm`
+{{< highlight bash >}}
+dnf update https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-x86_64-7033-br/Packages/l/linux-firmware-20230310-134.el9_2.alma.noarch.rpm
+{{< /highlight >}}
 
 
-To check that the installation completed successfully, you can run `rpm -qa linux-firmware`. 
+To check that the installation completed successfully, you can run:
+
+{{< highlight bash >}}
+rpm -qa linux-firmware
+{{< /highlight >}}
 
 **To update CPU microcode run the following:**
-`echo 1 > /sys/devices/system/cpu/microcode/reload`
 
-Once you have completed your testing, please help us by letting us know it works for you! Please share the following information (sanitized in whatever way you feel comfortable) in a comment on the issue we’ve opened to track this update on bugs.almalinux.org. We have created one specific to [AlmaLinux 8](https://bugs.almalinux.org/view.php?id=412) and one for [AlmaLinux 9](https://bugs.almalinux.org/view.php?id=413). Please include the output of the two commands from the test server.
+{{< highlight bash >}}
+echo 1 > /sys/devices/system/cpu/microcode/reload
+{{< /highlight >}}
 
-> Did it work for you? Yes or no.
+Once you have completed your testing, please help us by letting us know it works for you! Please share the following information (sanitized in whatever way you feel comfortable) in a comment on the issue we’ve opened to track this update on bugs.almalinux.org. We have created one specific to [AlmaLinux 8](https://bugs.almalinux.org/view.php?id=412) and one for [AlmaLinux 9](https://bugs.almalinux.org/view.php?id=413). Please include the output of the two commands from the test server and whether it worked for you.
 
-`lscpu`
-
-`journalctl -k --grep=microcode`
+{{< highlight bash >}}
+lscpu
+journalctl -k --grep=microcode
+{{< /highlight >}}
 
 
 ## Why call for testing now?

--- a/content/blog/zenbleed-patch-call-for-testing.md
+++ b/content/blog/zenbleed-patch-call-for-testing.md
@@ -32,20 +32,20 @@ You can see the diff of the changes on [git.almalinux.org](https://git.almalinux
 
 Due to the risks involved in these patches, these packages are not yet in production and need testing! If you are willing to help provide us feedback, and have access to a **bare metal AMD system**, you can manually install them by pulling them from the AlmaLinux Build System.  
 
-To install the new RPM on AlmaLinux 8: 
+**To install the new RPM on AlmaLinux 8:**
 
 {{< highlight bash >}}
 dnf update https://build.almalinux.org/pulp/content/builds/AlmaLinux-8-x86_64-7032-br/Packages/l/linux-firmware-20230404-114.git2e92a49f.el8_8.alma.noarch.rpm
 {{< /highlight >}}
 
-For AlmaLinux 9:
+**For AlmaLinux 9:**
 
 {{< highlight bash >}}
 dnf update https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-x86_64-7033-br/Packages/l/linux-firmware-20230310-134.el9_2.alma.noarch.rpm
 {{< /highlight >}}
 
 
-To check that the installation completed successfully, you can run:
+**To check that the installation completed successfully, you can run:**
 
 {{< highlight bash >}}
 rpm -qa linux-firmware


### PR DESCRIPTION
Current: https://almalinux.org/blog/zenbleed-patch-call-for-testing/

Preview: https://blog-syntax-highlighting.almalinux-org-11c.pages.dev/blog/zenbleed-patch-call-for-testing/

I believe this addresses the word wrap issues. Cleaned up a bit of the formatting as well.

@mattlasheboro helped with the CSS, so thank you!