### PR TITLE
Add markdown / highlight configuration / use different style

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -46,3 +46,7 @@ markup:
     goldmark:
         renderer:
             unsafe: true
+
+    highlight:
+      noClasses: true
+      style: xcode-dark


### PR DESCRIPTION
This adjusts the default highlight style from `monokai` to `xcode-dark` which fits our theme a bit better. It didn't get included in PR #275 