### PR TITLE
Make Long Links Break Into New Line Instead of Overflowing

### DIFF
--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -862,6 +862,8 @@ a:hover{
   border-radius: 10px;
   overflow-wrap: anywhere;
 }
-
+a {
+    overflow-wrap: anywhere;
+}
 
 /*# sourceMappingURL=bundle.css.map */

--- a/assets/scss/main.css
+++ b/assets/scss/main.css
@@ -836,4 +836,7 @@ a {
   .container {
     max-width: 1320px;
   }
+a {
+    overflow-wrap: anywhere;
+}
 }/*# sourceMappingURL=main.css.map */


### PR DESCRIPTION
Fixes:
https://github.com/AlmaLinux/almalinux.org/issues/279