### PR TITLE
Prevents Wide Images From Overflowing The Screen

### DIFF
--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -314,7 +314,7 @@ border-bottom-color: #14598a !important;
   color: #fefefe;
 }
 .al-page-blog-post article .al-article-content img {
-  max-width: 850px;
+  max-width: 100%;
 }
 .al-page-blog-post article .al-page-blog-author img {
   width: 40px;


### PR DESCRIPTION
Related Issue: #294.  

Some wide images in the blog section can overflow the display on mobile devices, introducing horizontal scrolling.  This PR addresses that.