### PR TITLE
Fixing security icons for mobile version

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -52,6 +52,10 @@
         flex: 0 0 auto;
         width: 16.66667%;
     }
+    .al-index-security-icon img {
+        width: 32px!important;
+        height: 32px!important;;
+    }
 }
 .h2, h2 {
     font-size: calc(1.325rem + .9vw);
@@ -303,7 +307,7 @@
                     
                     <div class="container-security" style="display: flex; justify-content: space-between;">
                         <div class="container-measure" style="display: flex; width: 32%;">
-                            <img loading="lazy" class="al-index-community-icon img" src="/images/errata-iconA.svg" style="height: 32px; width: 32px;">
+                            <img loading="lazy" class="al-index-security-icon img" src="/images/errata-iconA.svg" style="height: 32px; width: 32px;">
                             <div class="al-index-community-content-wrap" style="padding-left: 22px">
                                 <h4 class="fw-bold mb-0 pb-2">Errata</h4>
                                 <p>
@@ -312,16 +316,16 @@
                             </div>
                         </div>
                         <div class="container-measure" style="display: flex; width: 32%;">
-                            <img loading="lazy" class="al-index-community-icon img" src="/images/open_vul_assessment_icon_B.svg" style="height: 32px; width: 32px;">
+                            <img loading="lazy" class="al-index-security-icon img" src="/images/open_vul_assessment_icon_B.svg" style="height: 32px; width: 32px;">
                             <div class="al-index-community-content-wrap" style="padding-left: 22px">
                                 <h4 class="fw-bold mb-0 pb-2">OpenSCAP and OVAL</h4>
                                 <p>
-                                    {{ i18n "AlmaLinux OS provides SCAP and SCAP Workbench packages to audit your AlmaLinux system for security compliance alongside OVAL streams." }}"
+                                    {{ i18n "AlmaLinux OS provides SCAP and SCAP Workbench packages to audit your AlmaLinux system for security compliance alongside OVAL streams." }}
                                 </p>
                             </div>
                         </div>
                         <div class="container-measure" style="display: flex; width: 32%;">
-                            <img loading="lazy" class="al-index-community-icon img" src="/images/sbom_iconF.svg" style="height: 32px; width: 32px;">
+                            <img loading="lazy" class="al-index-security-icon img" src="/images/sbom_iconF.svg" style="height: 32px; width: 32px;">
                             <div class="al-index-community-content-wrap" style="padding-left: 22px">
                                 <h4 class="fw-bold mb-0 pb-2">Software Bill of Materials</h4>
                                 <p>


### PR DESCRIPTION
Currently, icons in the Security section mobile version are displayed not as expected. This may help. 

![img_1643](https://github.com/AlmaLinux/almalinux.org/assets/87830789/a01e45e3-4ee9-4aee-a67c-9c609bdc45e4)

@codyro @jonathanspw @bennyvasquez please take a look 