### PR TITLE
Adjust ABI phrasing.

### DIFF
--- a/content/blog/almalinux-os-brings-openqa-to-rhel.md
+++ b/content/blog/almalinux-os-brings-openqa-to-rhel.md
@@ -28,7 +28,7 @@ As I have been leading the openQA efforts, I rolled up my sleeves and got to wor
 First and foremost, while openQA worked well with Fedora, it did not yet work with RHEL. So the first order of business was submitting pull requests to make sure that openQA could identify RHEL and any other EL-derivative.
 During our work to implement openQA for AlmaLinux, we implemented virtualization support for s390x architecture in openQA. We also adapted it to work on the RHEL virtualization stack, bringing back KVM support in ppc64le architecture for AlmaLinux 9. KVM support was removed from RHEL, and as part of our 1:1 RHEL clone promise, KVM support has not been part of the “official” AlmaLinux 9 for ppc64le; it has only been implemented for openQA and corresponds with the Kernel and QEMU-KVM packages in the openQA repo.
 
-With the recent shift in our goals from 1:1 to ABI compatible, adding KVM support to our ppc64le images is something we might consider adding back in, afterall!
+With the recent shift in our goals from 1:1 to RHEL compatible, adding KVM support to our ppc64le images is something we might consider adding back in, afterall!
 
 Stay tuned for more in-depth insights into the development process and the challenges overcome by the AlmaLinux Team, as I will be sharing them soon.
 

--- a/content/blog/future-of-almalinux.md
+++ b/content/blog/future-of-almalinux.md
@@ -16,10 +16,10 @@ It’s been a whirlwind few weeks here at AlmaLinux, and I’m elated to be able
 
 ## The future of AlmaLinux OS
 
-In case you missed it, [Red Hat announced](https://www.redhat.com/en/blog/furthering-evolution-centos-stream) they will no longer be providing the means for downstream clones to continue to be 1:1 binary copies of Red Hat Enterprise Linux (RHEL). Very quickly, both [Jack](https://almalinux.org/blog/our-value-is-our-values/) and [I shared](https://almalinux.org/blog/impact-of-rhel-changes/) some initial thoughts, but we intentionally took our time deciding the next right step for AlmaLinux OS. After much discussion, the AlmaLinux OS Foundation board today has decided to drop the aim to be 1:1 with RHEL. AlmaLinux OS will instead aim to be Application Binary Interface (ABI) compatible*. 
+In case you missed it, [Red Hat announced](https://www.redhat.com/en/blog/furthering-evolution-centos-stream) they will no longer be providing the means for downstream clones to continue to be 1:1 binary copies of Red Hat Enterprise Linux (RHEL). Very quickly, both [Jack](https://almalinux.org/blog/our-value-is-our-values/) and [I shared](https://almalinux.org/blog/impact-of-rhel-changes/) some initial thoughts, but we intentionally took our time deciding the next right step for AlmaLinux OS. After much discussion, the AlmaLinux OS Foundation board today has decided to drop the aim to be 1:1 with RHEL. AlmaLinux OS will instead aim to be binary compatible with RHEL*. 
 
 
-_We will continue to aim to produce an enterprise-grade, long-term distribution of Linux that is aligned and ABI compatible with RHEL in response to our community’s needs, to the extent it is possible to do, and such that software that runs on RHEL will run the same on AlmaLinux._
+_We will continue to aim to produce an enterprise-grade, long-term distribution of Linux that is aligned and binary compatible with RHEL in response to our community’s needs, to the extent it is possible to do, and such that software that runs on RHEL will run the same on AlmaLinux._
  -- From yesterday's meeting notes: [Minutes - Board Meeting #23 July, 2023](https://drive.google.com/file/d/13q6udmzAEqHIoPf2cQJ-QJrYosaFWd_m/view)
 
 
@@ -61,4 +61,4 @@ There’s a lot of work to be done, and we are very excited to welcome you.
 
 –-
 
-\* [ABI compatibility](https://en.wikipedia.org/wiki/Application_binary_interface) in our case means working to ensure that applications built to run on RHEL (or RHEL clones) can run without issue on AlmaLinux. Adjusting to this expectation removes our need to ensure that everything we release is an exact copy of the source code that you would get with RHEL.
+\* [Binary/ABI compatibility](https://en.wikipedia.org/wiki/Application_binary_interface) in our case means working to ensure that applications built to run on RHEL (or RHEL clones) can run without issue on AlmaLinux. Adjusting to this expectation removes our need to ensure that everything we release is an exact copy of the source code that you would get with RHEL. This includes kernel compatibility and application compatibility. 

--- a/content/blog/new-repositories-for-almalinux-os-synergy-and-testing.md
+++ b/content/blog/new-repositories-for-almalinux-os-synergy-and-testing.md
@@ -11,7 +11,7 @@ post:
     image: /blog-images/new-repos-announcement.png
 ---
 
-Hello, Community! Since [AlmaLinux OS has shifted its direction to ABI compatibility](https://almalinux.org/blog/future-of-almalinux/), we can now provide additional content for our community. For that reason, two additional repositories have been added - **Testing** and **Synergy**. Today, we are announcing that both repositories are available for AlmaLinux OS 8 and AlmaLinux OS 9. 
+Hello, Community! Since [AlmaLinux OS has shifted its direction to RHEL compatibility](https://almalinux.org/blog/future-of-almalinux/), we can now provide additional content for our community. For that reason, two additional repositories have been added - **Testing** and **Synergy**. Today, we are announcing that both repositories are available for AlmaLinux OS 8 and AlmaLinux OS 9. 
 
 ## Testing Repository
 

--- a/content/blog/testers-needed-for-updated-packages-intel-and-amd-cpus-affected.md
+++ b/content/blog/testers-needed-for-updated-packages-intel-and-amd-cpus-affected.md
@@ -15,7 +15,7 @@ Earlier this week a few vulnerabilities were reported to affect Intel and AMD CP
 
 ### How do I install updated  packages?
 
- As we recently changed the build process for AlmaLinux OS, and are now aiming to be [ABI compatible](https://almalinux.org/blog/future-of-almalinux/) with Red Hat Enterprise Linux, we are now able to release updates without waiting for the patches to be released upstream. To help accommodate that, a **Testing** repo has been created for packages that differ from RHEL and require additional testing by our users. 
+ As we recently changed the build process for AlmaLinux OS, and are now aiming to be [RHEL compatible](https://almalinux.org/blog/future-of-almalinux/) with Red Hat Enterprise Linux, we are now able to release updates without waiting for the patches to be released upstream. To help accommodate that, a **Testing** repo has been created for packages that differ from RHEL and require additional testing by our users. 
 To be able to help with testing, the **Testing** repo should be enabled on the AlmaLinux machine:
 
 ```bash

--- a/content/blog/zenbleed-patch-call-for-testing.md
+++ b/content/blog/zenbleed-patch-call-for-testing.md
@@ -73,7 +73,7 @@ journalctl -k --grep=microcode
 
 ## Why call for testing now?
 
-The depth of this exploit is motivation for moving fast, in our opinion. Our users are looking for a patch to come quickly, and this is one more opportunity that we have as a result of our decision to aim for [ABI compatibility](https://almalinux.org/blog/future-of-almalinux/). We will be looking for more opportunities for testing and early/beta adopters as we expand. In fact, we have a kernel update in testing right now, that was shared in [chat.almalinux.org](https://chat.almalinux.org/almalinux/pl/5o5ffzjc53djtrifnuqdeb1ser) earlier today. If you have interest in helping us with testing, please do join us there!
+The depth of this exploit is motivation for moving fast, in our opinion. Our users are looking for a patch to come quickly, and this is one more opportunity that we have as a result of our decision to aim for [binary compatibility](https://almalinux.org/blog/future-of-almalinux/). We will be looking for more opportunities for testing and early/beta adopters as we expand. In fact, we have a kernel update in testing right now, that was shared in [chat.almalinux.org](https://chat.almalinux.org/almalinux/pl/5o5ffzjc53djtrifnuqdeb1ser) earlier today. If you have interest in helping us with testing, please do join us there!
 
 
 ## Come help!

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -76,7 +76,7 @@
                         {{ i18n "Free Linux OS for the community, by the community" }}
                     </h1>
                     <p class="lead mb-5 mb-md-3">
-                        {{ i18n "An Open Source, community owned and governed, forever-free enterprise Linux distribution, focused on long-term stability, providing a robust production-grade platform. AlmaLinux OS is ABI compatible with RHEL®." }}
+                        {{ i18n "An Open Source, community owned and governed, forever-free enterprise Linux distribution, focused on long-term stability, providing a robust production-grade platform. AlmaLinux OS is binary compatible with RHEL®." }}
                     </p>
                     <div class="d-grid gap-3 d-md-flex justify-content-md-start pt-3">
                         <a href="{{ "/contribute" | relLangURL }}" class="btn btn-lg px-4 me-md-2 al-hero-cta-primary">
@@ -170,7 +170,7 @@
                     <div class="col-12 col-md-12">
                         <h2 class="pb-3">{{ i18n "About AlmaLinux OS" }}</h2>
                         <p>
-                            {{ i18n "AlmaLinux OS is an open-source, community-driven Linux operating system that fills the gap left by the discontinuation of the CentOS Linux stable release. AlmaLinux OS is an Enterprise Linux distro, ABI compatible with RHEL®, and guided and built by the community." }}
+                            {{ i18n "AlmaLinux OS is an open-source, community-driven Linux operating system that fills the gap left by the discontinuation of the CentOS Linux stable release. AlmaLinux OS is an Enterprise Linux distro, binary compatible with RHEL®, and guided and built by the community." }}
                         </p>
                         <p>
                             {{ i18n "As a standalone, completely free OS, AlmaLinux OS enjoys $1M in annual sponsorship from CloudLinux Inc. and support from more than 25 other sponsors. Ongoing development efforts are governed by the members of the community." }}
@@ -608,7 +608,7 @@
                         </h2>
                         <div id="flush-collapse-1" class="accordion-collapse collapse show" aria-labelledby="flush-heading-1" data-parent="#accordionFAQ" >
                          <div class="accordion-body">
-                             {{ i18n "Individuals and organizations that require an enterprise-grade, Fedora-like distribution but who do not want to or cannot pay for a RHEL® license. AlmaLinux OS is also a perfect replacement for anyone who currently relies on the CentOS stable release to achieve computing objectives." }}
+                             {{ i18n "Individuals and organizations that require an enterprise-grade linux distribution, without the need for a commercial license agreement. AlmaLinux OS is also a perfect replacement for anyone who has historically relied on CentOS Linux release to achieve computing objectives, and for whom CentOS Stream is not the right solution." }}
                           </div>
                         </div>
                    </div>
@@ -634,7 +634,7 @@
                         </h2>
                         <div id="flush-collapse-3" class="accordion-collapse collapse" aria-labelledby="flush-heading-3" data-parent="#accordionFAQ" >
                             <div class="accordion-body">
-                                {{ i18n "We’re already doing it – experience with RHEL forks towards CloudLinux. We have the staff, the capabilities, the resources. Frankly: we want to put ourselves on the map re CloudLinux and KernelCare. It is worth the effort." }}
+                                {{ i18n "The initial backers and supporters for AlmaLinux OS were already extremely active in the enterprise Linux ecosystem, and had significant experience with RHEL forks. They knew the impact that the loss of CentOS Linux would have across all industries, and had the means and knowledge to help." }}
                             </div>
                         </div>
                     </div>
@@ -642,25 +642,12 @@
                     <div class="accordion-item mb-3">
                         <h2 class="accordion-header" id="flush-heading-4">
                             <button class="accordion-button collapsed" type="button" data-toggle="collapse" data-target="#flush-collapse-4" aria-expanded="true" aria-controls="flush-collapse-4">
-                                {{ i18n "How is the community protected from future course changes?" }}
+                                {{ i18n "How is the community protected from future course changes for AlmaLinux OS?" }}
                             </button>
                         </h2>
                         <div id="flush-collapse-4" class="accordion-collapse collapse" aria-labelledby="flush-heading-4" data-parent="#accordionFAQ" >
                             <div class="accordion-body">
-                                {{ i18n "We are involving the community right through the process, including in the governing board. At all times, AlmaLinux OS will be free and open. The community can pick the project at any time." }}
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="accordion-item mb-3">
-                        <h2 class="accordion-header" id="flush-heading-5">
-                            <button class="accordion-button collapsed" type="button" data-toggle="collapse" data-target="#flush-collapse-5" aria-expanded="true" aria-controls="flush-collapse-5">
-                                {{ i18n "Why should I rely on CloudLinux for a CentOS alternative?" }}
-                            </button>
-                        </h2>
-                        <div id="flush-collapse-5" class="accordion-collapse collapse " aria-labelledby="flush-heading-5" data-parent="#accordionFAQ">
-                            <div class="accordion-body">
-                                {{ i18n "CloudLinux's core product, the CloudLinux OS, is a RHEL® fork that has been in place for over ten years. More than 4,000 companies including Dell, Liquid Web, and 1&1 rely on the CloudLinux OS across more than 200,000 product installations. CloudLinux has proven experience in creating and maintaining a RHEL fork and have done so starting with RHEL release 5, right through to release 8. AlmaLinux OS is an opportunity for us to channel our expertise in RHEL into a Linux distribution that serves the broader community. Furthermore, we are including the Linux community right from the inception of AlmaLinux OS. Moving forward, community members will be on the governing board for the AlmaLinux OS project and involved in key decisions too. Finally, AlmaLinux OS will always be free and open source. The community can pick up and continue to develop AlmaLinux OS at any time." }}
+                                {{ i18n "The AlmaLinux OS Foundation is a 501(c)(3) that was founded in March of 2021 to own and manage the AlmaLinux OS project. We have been involving the community since the beginning, and the governing board is chosen by members of the foundation. At all times, AlmaLinux OS will be free and open." }}
                             </div>
                         </div>
                     </div>
@@ -673,7 +660,7 @@
                         </h2>
                         <div id="flush-collapse-6" class="accordion-collapse collapse " aria-labelledby="flush-heading-6" data-parent="#accordionFAQ">
                             <div class="accordion-body">
-                                {{ i18n "Switching Linux distros can be a headache, but that is not the case when switching from CentOS to AlmaLinux OS. Using ELevate (developed and maintained by the AlmaLinux Community), you can migrate to AlmaLinux in place." }}
+                                {{ i18n "Switching Linux distros can be a headache, but that is not the case when switching from CentOS to AlmaLinux OS. Using " }} <a href="https://almalinux.org/elevate">{{ i18n "ELevate" }}</a> {{ " (developed and maintained by the AlmaLinux Community), you can migrate to AlmaLinux in-place." }}
                             </div>
                         </div>
                     </div>
@@ -686,7 +673,7 @@
                         </h2>
                         <div id="flush-collapse-7" class="accordion-collapse collapse " aria-labelledby="flush-heading-7" data-parent="#accordionFAQ">
                             <div class="accordion-body">
-                                {{ i18n "Since AlmaLinux is ABI compatible with RHEL®, your applications and services should be completely interoperable. You can rapidly migrate any number of servers using the [migration tool](https://github.com/AlmaLinux/almalinux-deploy)." }}
+                                {{ i18n "Since AlmaLinux is binary compatible with RHEL®, your applications and services should be completely interoperable. You can rapidly migrate any number of servers using the [migration tool](https://github.com/AlmaLinux/almalinux-deploy)." }}
 
                                 {{ i18n "If you are using CentOS 7 or 8 and need help upgrading and migrating, check out" }} <a href="https://almalinux.org/elevate">{{ i18n "ELevate." }}</a> 
                             </div>
@@ -696,12 +683,12 @@
                     <div class="accordion-item mb-3">
                         <h2 class="accordion-header" id="flush-heading-8">
                             <button class="accordion-button collapsed" type="button" data-toggle="collapse" data-target="#flush-collapse-8" aria-expanded="true" aria-controls="flush-collapse-8">
-                                {{ i18n "Until when will we support AlmaLinux OS 8?" }}
+                                {{ i18n "When will support AlmaLinux OS 8 reach end of life?" }}
                             </button>
                         </h2>
                         <div id="flush-collapse-8" class="accordion-collapse collapse " aria-labelledby="flush-heading-8" data-parent="#accordionFAQ">
                             <div class="accordion-body">
-                                {{ i18n "AlmaLinux OS partners has committed to supporting AlmaLinux OS 8 at least until 2029, including stable and thoroughly tested updates and security patches." }}
+                                {{ i18n "AlmaLinux OS has committed to supporting AlmaLinux OS 8 until 2029, including stable and thoroughly tested updates and security patches." }}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
We have received a TON of feedback that folks who read our updates are confused by the 'ABI' part of what we're saying, so we're adjusting references to ABI to say 'binary' instead. This seems to be enough to assuage concerns and fix the misunderstandings when we're talking to folks, so I'm hoping this is the only change that's really needed. 

Adjusted references to ABI compatibility in all blogs that have mentioned it. Also updated the FAQ for the homepage while I was in there.

