### PR TITLE
Add Open Graph support

### DIFF
--- a/content/blog/2023-09-07-almalinux-events-2023.md
+++ b/content/blog/2023-09-07-almalinux-events-2023.md
@@ -6,6 +6,8 @@ author:
  bio: "Longtime open source user, advocate, and contributor"
  image: /users/JoeBrockmeier.jpg
 date: 2023-09-07
+images:
+  - /blog-images/23.09.07.fallevents.svg
 post: 
     title: "AlmaLinux Live: Coming to a city near you"
     image: /blog-images/23.09.07.fallevents.svg

--- a/content/blog/2023-09-14-election-2023.md
+++ b/content/blog/2023-09-14-election-2023.md
@@ -6,6 +6,8 @@ author:
  bio: "Chair, AlmaLinux OS Foundation"
  image: /users/benny.jpeg
 date: 2023-09-14
+images:
+  - /blog-images/23.09.14.election.svg
 post: 
     title: "The AlmaLinux OS Foundation is hosting another election this year!"
     image: /blog-images/23.09.14.election.svg

--- a/content/blog/2023-09-19-fips-validation-for-almalinux.md
+++ b/content/blog/2023-09-19-fips-validation-for-almalinux.md
@@ -6,6 +6,8 @@ author:
  bio: "Security Standards Architect"
  image: /users/sjohn.png
 date: '2023-09-19'
+images:
+  - /blog-images/fips140.png
 post:
     title: "FIPS Validation for AlmaLinux OS"
     image: /blog-images/fips140.png

--- a/content/blog/2023-09-26-almalinux-jupyter.md
+++ b/content/blog/2023-09-26-almalinux-jupyter.md
@@ -6,6 +6,8 @@ author:
  bio: "MA, Senior Linux DevOps Engineer, University of California, Santa Barbara"
  image: /users/vwbusguy.jpg
 date: '2023-09-26'
+images:
+  - /blog-images/23.09.26.ucsb_blog.svg
 post:
   title: "Learn about how UCSB uses Almalinux in day-to-day operations."
   image: /blog-images/23.09.26.ucsb_blog.svg

--- a/content/blog/2023-10-26-announcing-93-beta.md
+++ b/content/blog/2023-10-26-announcing-93-beta.md
@@ -6,6 +6,8 @@ author:
  bio: "AlmaLinux Community Manager"
  image: /users/jack.jpg
 date: '2023-10-26'
+images:
+  - /blog-images/23.10.26.93beta.jpg
 post:
     title: "Announcing AlmaLinux 9.3 Beta!"
     image: /blog-images/23.10.26.93beta.jpg

--- a/content/blog/2023-11-02-announcing-89-beta.md
+++ b/content/blog/2023-11-02-announcing-89-beta.md
@@ -6,6 +6,8 @@ author:
  bio: "AlmaLinux Community Manager"
  image: /users/jack.jpg
 date: '2023-11-02'
+images:
+  - /blog-images/23.11.02.89beta.jpg
 post:
     title: "Announcing AlmaLinux 8.9 Beta!"
     image: /blog-images/23.11.02.89beta.jpg

--- a/content/blog/2023-11-13-announcing-93-stable.md
+++ b/content/blog/2023-11-13-announcing-93-stable.md
@@ -6,6 +6,8 @@ author:
  bio: "AlmaLinux Community Manager"
  image: /users/jack.jpg
 date: '2023-11-13'
+images:
+  - /blog-images/23.11.13.93stable.jpg
 post:
     title: "Announcing AlmaLinux 9.3 Stable!"
     image: /blog-images/23.11.13.93stable.jpg

--- a/content/blog/2023-11-13-announcing-aldt.md
+++ b/content/blog/2023-11-13-announcing-aldt.md
@@ -6,6 +6,8 @@ author:
  bio: "Chair, AlmaLinux OS Foundation"
  image: /users/benny.jpeg
 date: 2023-11-13
+images:
+  - /blog-images/2023-11-13-announcing-aldt-2023.png
 post: 
     title: "Announcing AlmaLinux Day Tokyo"
     image: /blog-images/2023-11-13-announcing-aldt-2023.png

--- a/content/blog/new-repositories-for-almalinux-os-synergy-and-testing.md
+++ b/content/blog/new-repositories-for-almalinux-os-synergy-and-testing.md
@@ -6,6 +6,8 @@ author:
  bio: "Release Engineering Lead"
  image: /users/alukoshko.jpg
 date: '2023-08-24'
+images:
+  - /blog-images/new-repos-announcement.png
 post:
     title: "Welcome new repositories for AlmaLinux OS: Testing and Synergy"
     image: /blog-images/new-repos-announcement.png

--- a/content/blog/testers-needed-for-updated-packages-intel-and-amd-cpus-affected.md
+++ b/content/blog/testers-needed-for-updated-packages-intel-and-amd-cpus-affected.md
@@ -6,6 +6,8 @@ author:
  bio: "Release Engineering Lead"
  image: /users/alukoshko.jpg
 date: '2023-08-14'
+images:
+  - /blog-images/testers-post.png
 post:
     title: "Testers needed for security updates: Intel and AMD CPUs affected"
     image: /blog-images/testers-post.png

--- a/content/blog/welcoming-openlogic-hawkhost-almalinux-os-foundation.md
+++ b/content/blog/welcoming-openlogic-hawkhost-almalinux-os-foundation.md
@@ -6,6 +6,8 @@ author:
  bio: "-"
  image: /users/benny.jpeg
 date: '2023-03-20'
+images:
+  - /blog-images/23.03.20.png
 post:
     title: "OpenLogic and Hawk Host join the AlmaLinux OS Foundation"
     image: /blog-images/23.03.20.png

--- a/content/blog/zenbleed-patch-call-for-testing.md
+++ b/content/blog/zenbleed-patch-call-for-testing.md
@@ -6,6 +6,8 @@ author:
  bio: "Release Engineering Lead"
  image: /users/alukoshko.jpg
 date: '2023-07-24'
+images:
+  - /blog-images/23.07.24.zenbleed.png
 post:
     title: "Testers needed: Zenbleed patch for AlmaLinux 8 and 9"
     image: /blog-images/23.07.24.zenbleed.png

--- a/layouts/partials/common/head.html
+++ b/layouts/partials/common/head.html
@@ -4,6 +4,10 @@
     <!-- This website is Open Source!                     -->
     <!-- Visit https://github.com/AlmaLinux/almalinux.org -->
 
+    <!-- OpenGraph -->
+    <!-- We don't use the internal template because we modify the logic -->
+    {{ partial "common/opengraph.html" . }}
+
     <meta charset="UTF-8">
     <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0" name="viewport">
     <meta content="ie=edge" http-equiv="X-UA-Compatible">
@@ -60,13 +64,4 @@
 
     {{$bundleCSS := resources.Get  "css/bundle.css" | resources.Minify | resources.Fingerprint }}
     <link rel="stylesheet" href="{{ $bundleCSS.RelPermalink }}" integrity="{{ $bundleCSS.Data.Integrity }}"/>
-
-  
-        
-        <meta property="og:image" content="/images/hero.png">
-        <meta property="og:url" content="https://almalinux.org/">
-        <meta property="og:type" content="website">
-        <meta name="twitter:card" content="summary_large_image">
-        <meta property="og:locale" content="en">
-    
 </head>

--- a/layouts/partials/common/opengraph.html
+++ b/layouts/partials/common/opengraph.html
@@ -1,0 +1,64 @@
+<meta property="og:title" content="{{ .Title }}" />
+<meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
+<meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
+<meta property="og:url" content="{{ .Permalink }}" />
+
+{{- with $.Params.images -}}
+    {{- range first 6 . }}<meta property="og:image" content="{{ . | absURL }}" />{{ end -}}
+{{- else -}}
+    {{- $images := $.Resources.ByType "image" -}}
+    {{- $featured := $images.GetMatch "*feature*" -}}
+    {{- if not $featured }}{{ $featured = $images.GetMatch "{*cover*,*thumbnail*}" }}{{ end -}}
+    {{- with $featured -}}
+        <meta property="og:image" content="{{ $featured.Permalink }}"/>
+    {{- else -}}
+        {{- with $.Site.Params.images }}<meta property="og:image" content="{{ index . 0 | absURL }}"/>{{ end -}}
+        {{- if not $.Site.Params.images -}}
+            <!-- Default image if no other image is found -->
+            <meta property="og:image" content="{{ "images/hero.png" | absURL }}"/>
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+
+{{- if .IsPage }}
+{{- $iso8601 := "2006-01-02T15:04:05-07:00" -}}
+<meta property="article:section" content="{{ .Section }}" />
+{{ with .PublishDate }}<meta property="article:published_time" {{ .Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />{{ end }}
+{{ with .Lastmod }}<meta property="article:modified_time" {{ .Format $iso8601 | printf "content=%q" | safeHTMLAttr }} />{{ end }}
+{{- end -}}
+
+{{- with .Params.audio }}<meta property="og:audio" content="{{ . }}" />{{ end }}
+{{- with .Params.locale }}<meta property="og:locale" content="{{ . }}" />{{ end }}
+{{- with .Site.Params.title }}<meta property="og:site_name" content="{{ . }}" />{{ end }}
+{{- with .Params.videos }}{{- range . }}
+<meta property="og:video" content="{{ . | absURL }}" />
+{{ end }}{{ end }}
+
+{{- /* If it is part of a series, link to related articles */}}
+{{- $permalink := .Permalink }}
+{{- $siteSeries := .Site.Taxonomies.series }}
+{{- if $siteSeries }}
+{{ with .Params.series }}{{- range $name := . }}
+  {{- $series := index $siteSeries ($name | urlize) }}
+  {{- range $page := first 6 $series.Pages }}
+    {{- if ne $page.Permalink $permalink }}<meta property="og:see_also" content="{{ $page.Permalink }}" />{{ end }}
+  {{- end }}
+{{ end }}{{ end }}
+{{- end }}
+
+{{- /* Deprecate site.Social.facebook_admin in favor of site.Params.social.facebook_admin */}}
+{{- $facebookAdmin := "" }}
+{{- with site.Params.social }}
+  {{- if reflect.IsMap . }}
+    {{- $facebookAdmin = .facebook_admin }}
+  {{- end }}
+{{- else }}
+  {{- with site.Social.facebook_admin }}
+    {{- $facebookAdmin = . }}
+    {{- warnf "The social key in site configuration is deprecated. Use params.social.facebook_admin instead." }}
+  {{- end }}
+{{- end }}
+
+{{- /* Facebook Page Admin ID for Domain Insights */}}
+{{ with $facebookAdmin }}<meta property="fb:admins" content="{{ . }}" />{{ end }}


### PR DESCRIPTION
This PR adds an Open Graph template, enabling support on all/any of the pages on the website. 

Some notes:

* Instead of using the [internal Open Graph template](https://gohugo.io/templates/internal/#use-the-open-graph-template) from Hugo, I have created a template with some modified logic for our needs (EX, serve default Open Graph image when none are detected)
* Added basic metadata to recent blog posts to serve the image in the blog post (`images[]` array in the front matter)

We need a good default image to serve if none is detected. Right now, it uses what it has been for all of these years, https://almalinux.org/images/hero.png, which is *not* ideal. @mattlasheboro can you help come up with a reasonable default image for this?