### PR TITLE
Remove Docker Hub the ALDT page social links

### DIFF
--- a/layouts/aldt-2023/single.html
+++ b/layouts/aldt-2023/single.html
@@ -459,7 +459,6 @@
 				  <li class="social-item-lists sociallist"><a href="http://lists.almalinux.org">lists.almalinux.org</a></li>
 				  <li class="social-item-discourse sociallist"><a href="http://almalinux.discourse.group">almalinux.discourse.group</a></li>
 				  <li class="social-item-github sociallist"><a href="http://github.com/AlmaLinux">github.com/AlmaLinux</a></li>
-				  <li class="social-item-docker sociallist"><a href="http://hub.docker.com/_/almalinux">hub.docker.com/_/almalinux</a></li>
 				  <li class="social-item-wiki sociallist"><a href="http://wiki.almalinux.org/">wiki.almalinux.org</a></li>
 				</ul>
           </div>


### PR DESCRIPTION
The Docker Hub page shouldn't be listed with the rest of our socials.