### PR TITLE
fix: consistently use quay.io/repository/almalinuxorg in link text

### DIFF
--- a/layouts/get-almalinux/single.html
+++ b/layouts/get-almalinux/single.html
@@ -765,7 +765,7 @@
                             <div class="link-items">
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/9-minimal">quay.io/repository/almalinux/9-minimal</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/9-minimal">quay.io/repository/almalinuxorg/9-minimal</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/9-minimal">hub.docker.com/r/almalinux/9-minimal</a>
                                 </p>
                               </div>
@@ -777,13 +777,13 @@
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/9-init">quay.io/repository/almalinux/9-init</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/9-init">quay.io/repository/almalinuxorg/9-init</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/9-init">hub.docker.com/r/almalinux/9-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/9-micro">quay.io/repository/almalinux/9-micro</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/9-micro">quay.io/repository/almalinuxorg/9-micro</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/9-micro">hub.docker.com/r/almalinux/9-micro</a>
                                 </p>
                               </div>
@@ -839,7 +839,7 @@
                             <div class="link-items">
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/8-minimal">quay.io/repository/almalinux/8-minimal</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/8-minimal">quay.io/repository/almalinuxorg/8-minimal</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/8-minimal">hub.docker.com/r/almalinux/8-minimal</a>
                                 </p>
                               </div>
@@ -851,13 +851,13 @@
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/8-init">quay.io/repository/almalinux/8-init</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/8-init">quay.io/repository/almalinuxorg/8-init</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/8-init">hub.docker.com/r/almalinux/8-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/8-micro">quay.io/repository/almalinux/8-micro</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/8-micro">quay.io/repository/almalinuxorg/8-micro</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/8-micro">hub.docker.com/r/almalinux/8-micro</a>
                                 </p>
                               </div>
@@ -1353,7 +1353,7 @@
                             <div class="link-items">
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/9-minimal">quay.io/repository/almalinux/9-minimal</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/9-minimal">quay.io/repository/almalinuxorg/9-minimal</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/9-minimal">hub.docker.com/r/almalinux/9-minimal</a>
                                 </p>
                               </div>
@@ -1365,13 +1365,13 @@
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/9-init">quay.io/repository/almalinux/9-init</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/9-init">quay.io/repository/almalinuxorg/9-init</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/9-init">hub.docker.com/r/almalinux/9-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/9-micro">quay.io/repository/almalinux/9-micro</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/9-micro">quay.io/repository/almalinuxorg/9-micro</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/9-micro">hub.docker.com/r/almalinux/9-micro</a>
                                 </p>
                               </div>
@@ -1427,7 +1427,7 @@
                             <div class="link-items">
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/8-minimal">quay.io/repository/almalinux/8-minimal</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/8-minimal">quay.io/repository/almalinuxorg/8-minimal</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/8-minimal">hub.docker.com/r/almalinux/8-minimal</a>
                                 </p>
                               </div>
@@ -1439,13 +1439,13 @@
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/8-init">quay.io/repository/almalinux/8-init</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/8-init">quay.io/repository/almalinuxorg/8-init</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/8-init">hub.docker.com/r/almalinux/8-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/8-micro">quay.io/repository/almalinux/8-micro</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/8-micro">quay.io/repository/almalinuxorg/8-micro</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/8-micro">hub.docker.com/r/almalinux/8-micro</a>
                                 </p>
                               </div>
@@ -1821,7 +1821,7 @@
                             <div class="link-items">
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/9-minimal">quay.io/repository/almalinux/9-minimal</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/9-minimal">quay.io/repository/almalinuxorg/9-minimal</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/9-minimal">hub.docker.com/r/almalinux/9-minimal</a>
                                 </p>
                               </div>
@@ -1833,13 +1833,13 @@
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/9-init">quay.io/repository/almalinux/9-init</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/9-init">quay.io/repository/almalinuxorg/9-init</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/9-init">hub.docker.com/r/almalinux/9-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/9-micro">quay.io/repository/almalinux/9-micro</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/9-micro">quay.io/repository/almalinuxorg/9-micro</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/9-micro">hub.docker.com/r/almalinux/9-micro</a>
                                 </p>
                               </div>
@@ -1895,7 +1895,7 @@
                             <div class="link-items">
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/8-minimal">quay.io/repository/almalinux/8-minimal</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/8-minimal">quay.io/repository/almalinuxorg/8-minimal</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/8-minimal">hub.docker.com/r/almalinux/8-minimal</a>
                                 </p>
                               </div>
@@ -1907,13 +1907,13 @@
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/8-init">quay.io/repository/almalinux/8-init</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/8-init">quay.io/repository/almalinuxorg/8-init</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/8-init">hub.docker.com/r/almalinux/8-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/8-micro">quay.io/repository/almalinux/8-micro</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/8-micro">quay.io/repository/almalinuxorg/8-micro</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/8-micro">hub.docker.com/r/almalinux/8-micro</a>
                                 </p>
                               </div>
@@ -2206,7 +2206,7 @@
                             <div class="link-items">
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/9-minimal">quay.io/repository/almalinux/9-minimal</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/9-minimal">quay.io/repository/almalinuxorg/9-minimal</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/9-minimal">hub.docker.com/r/almalinux/9-minimal</a>
                                 </p>
                               </div>
@@ -2218,13 +2218,13 @@
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/9-init">quay.io/repository/almalinux/9-init</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/9-init">quay.io/repository/almalinuxorg/9-init</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/9-init">hub.docker.com/r/almalinux/9-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/9-micro">quay.io/repository/almalinux/9-micro</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/9-micro">quay.io/repository/almalinuxorg/9-micro</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/9-micro">hub.docker.com/r/almalinux/9-micro</a>
                                 </p>
                               </div>
@@ -2280,7 +2280,7 @@
                             <div class="link-items">
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/8-minimal">quay.io/repository/almalinux/8-minimal</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/8-minimal">quay.io/repository/almalinuxorg/8-minimal</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/8-minimal">hub.docker.com/r/almalinux/8-minimal</a>
                                 </p>
                               </div>
@@ -2292,13 +2292,13 @@
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/8-init">quay.io/repository/almalinux/8-init</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/8-init">quay.io/repository/almalinuxorg/8-init</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/8-init">hub.docker.com/r/almalinux/8-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
-                                  <a href="https://quay.io/repository/almalinuxorg/8-micro">quay.io/repository/almalinux/8-micro</a><br>
+                                  <a href="https://quay.io/repository/almalinuxorg/8-micro">quay.io/repository/almalinuxorg/8-micro</a><br>
                                   <a href="https://hub.docker.com/r/almalinux/8-micro">hub.docker.com/r/almalinux/8-micro</a>
                                 </p>
                               </div>


### PR DESCRIPTION
The [get-almalinux](https://almalinux.org/get-almalinux/#Container_Images) page links to the correct quay.io repository orgnization `almalinuxorg`, but the link text still points to an older repository organization that is not updated anymore. This is confusing to users as they only see the new repository when hovering over the link, and potentially results in users running without outdated and non-secure containers. Many users may just copy the text to their command line for pulling with docker or podman, without checking the link target.

This PR modifies only the link text to use the identical repository organization `almalinuxorg` as the link target.