### PR TITLE
Resources no more linked to AlmaLinux email

### DIFF
--- a/layouts/partials/common/footer.html
+++ b/layouts/partials/common/footer.html
@@ -5,7 +5,7 @@
                 <img src="/images/icon.svg" alt="AlmaLinux OS icon" class="mb-3" height="64">
                 <div class="d-block mb-3">© 2024 AlmaLinux OS Foundation</div>
 				<div>20791 Three Oaks Pkwy, #980<br />Estero, FL 33929</div>
-				<div><a href="mailto:hello@almalinux.org">hello@almalinux.org</div>
+				<div><a href="mailto:hello@almalinux.org">hello@almalinux.org</a></div>
             </div>
             <div class="col-6 col-md">
                 <h5>Resources</h5>


### PR DESCRIPTION
Currently for a reason the Resources in the footer are linked to the AlmaLinux email from our contacts, looks like it needs to be fixed 