### PR TITLE
Fix template to support language direction in the config

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ .Site.Language.Lang }}" dir="{{ .Site.Language.LanguageDirection | default "ltr" }}">
 {{- partial "common/head.html" . -}}
 
 


### PR DESCRIPTION
Example result:

```html
<html lang="he" dir="rtl">
```

- Refs #498