### PR TITLE
Use relLangURL for most href

### DIFF
--- a/layouts/ato-2023/single.html
+++ b/layouts/ato-2023/single.html
@@ -116,7 +116,7 @@
           <p>
             {{ i18n "AlmaLinux OS is an enterprise Linux operating system that is used across the globe for enterprise and hobbyist needs alike." }} 
             {{ i18n "When we got our start we were a downstream rebuild of Red Hat Enterprise Linux, but earlier this year we shifted to" }}
-            <a href="https://almalinux.org/blog/future-of-almalinux/" style="color: white;">{{ i18n "maintaining compatibility with RHEL" }}</a> {{ i18n "for our community. With over 500,000 servers calling out to one of our 300+" }}
+            <a href="{{ "blog/future-of-almalinux/" | relLangURL }}" style="color: white;">{{ i18n "maintaining compatibility with RHEL" }}</a> {{ i18n "for our community. With over 500,000 servers calling out to one of our 300+" }}
             <a href="https://mirrors.almalinux.org/" style="color: white;">{{ i18n "geo-located mirrors" }}</a> {{ i18n "every night, the adoption of AlmaLinux since our inception just over 2.5 years ago has both humbled and ignited us." }}
           </p>
         </div>
@@ -177,7 +177,7 @@
           </div>
           <div class="distro-item-2" style="width: 50%; padding-left: 40px; display: flex; flex-direction: column; justify-content: space-between;">
             <p style="line-height: 28px; letter-spacing: 0.25px;">
-              {{ i18n "As users of the historic CentOS, we have been working diligently to solve the problems and pain points that we all experienced, and one way we’ve done that is with" }} <a href="https://almalinux.org/elevate/" style="color: white;">{{ i18n "Project ELevate" }}</a>. {{ i18n "ELevate allows you to upgrade your enterprise linux operating system between major versions in place. No more having to migrate all of your data, instead ELevate your distribution!" }}
+              {{ i18n "As users of the historic CentOS, we have been working diligently to solve the problems and pain points that we all experienced, and one way we’ve done that is with" }} <a href="{{ "elevate/" | relLangURL }}" style="color: white;">{{ i18n "Project ELevate" }}</a>. {{ i18n "ELevate allows you to upgrade your enterprise linux operating system between major versions in place. No more having to migrate all of your data, instead ELevate your distribution!" }}
             </p>
             <p style="font-size: 13px; line-height: 28px; letter-spacing: 0.25px;">
               {{ i18n "* - migration to CentOS Stream 9 is currently in development and will be available later." }} <br>
@@ -225,7 +225,7 @@
                         </div>
                     </div>
                      <br><p>
-                        {{ i18n "AlmaLinux OS provides a set of security features: Errata, GPG keys, Mailing Lists, OpenSCAP, OVAL, SBOM" }}- <a href="/security" style="color: white;">{{ i18n "read more" }}</a>.
+                        {{ i18n "AlmaLinux OS provides a set of security features: Errata, GPG keys, Mailing Lists, OpenSCAP, OVAL, SBOM" }}- <a href="{{ "security" | relLangURL }}" style="color: white;">{{ i18n "read more" }}</a>.
                     </p>
                 </div>
             </div>

--- a/layouts/contribute/single.html
+++ b/layouts/contribute/single.html
@@ -65,7 +65,7 @@
                     </a>
                 </div>
                 <div>
-                    <a href="/members"
+                    <a href="{{ "members" | relLangURL }}"
                        class="btn al-member-button btn-lg px-4 mt-3">
                        <i class="bi bi-people-fill pe-1"></i>
                         {{ i18n "Become a Member" }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -330,7 +330,7 @@
                         </div>
                     </div>
                      <br><p>
-                        {{ i18n "AlmaLinux OS provides a set of security features: Errata, GPG keys, Mailing Lists, OpenSCAP, OVAL, SBOM, and Secure Boot" }}- <a href="/security">{{ i18n "read more" }}</a>.
+                        {{ i18n "AlmaLinux OS provides a set of security features: Errata, GPG keys, Mailing Lists, OpenSCAP, OVAL, SBOM, and Secure Boot" }}- <a href="{{ "security" | relLangURL }}">{{ i18n "read more" }}</a>.
                     </p>
                 </div>
             </div>
@@ -638,7 +638,7 @@
                         </h2>
                         <div id="flush-collapse-2" class="accordion-collapse collapse" aria-labelledby="flush-heading-2" data-parent="#accordionFAQ" >
                             <div class="accordion-body">
-                                {{ i18n "In July of 2023, " }} <a href="https://almalinux.org/blog/future-of-almalinux/">{{ i18n "we announced" }}</a> {{ i18n " that we were shifting our goal from being a downstream rebuild of RHEL to maintaining ABI compatibility with RHEL. For the AlmaLinux team that means that everything from software applications to kernel modules that work on RHEL will work on AlmaLinux, and if they don't we would consider that a bug." }}
+                                {{ i18n "In July of 2023, " }} <a href="{{ "blog/future-of-almalinux/" | relLangURL }}">{{ i18n "we announced" }}</a> {{ i18n " that we were shifting our goal from being a downstream rebuild of RHEL to maintaining ABI compatibility with RHEL. For the AlmaLinux team that means that everything from software applications to kernel modules that work on RHEL will work on AlmaLinux, and if they don't we would consider that a bug." }}
                             </div>
                         </div>
                     </div>
@@ -651,7 +651,7 @@
                         </h2>
                         <div id="flush-collapse-3" class="accordion-collapse collapse" aria-labelledby="flush-heading-3" data-parent="#accordionFAQ" >
                             <div class="accordion-body">
-                                {{ i18n "AlmaLinux OS 9.2 is FIPS-140 compliant. Read more in this blog post: " }} <a href="https://almalinux.org/blog/2023-09-19-fips-validation-for-almalinux/">{{ i18n "FIPS Validation for AlmaLinux OS" }}</a>
+                                {{ i18n "AlmaLinux OS 9.2 is FIPS-140 compliant. Read more in this blog post: " }} <a href="{{ "blog/2023-09-19-fips-validation-for-almalinux/" | relLangURL }}">{{ i18n "FIPS Validation for AlmaLinux OS" }}</a>
                             </div>
                         </div>
                     </div>
@@ -703,7 +703,7 @@
                         </h2>
                         <div id="flush-collapse-7" class="accordion-collapse collapse " aria-labelledby="flush-heading-7" data-parent="#accordionFAQ">
                             <div class="accordion-body">
-                                {{ i18n "Switching Linux distros can be a headache, but that is not the case when switching from CentOS to AlmaLinux OS. Using " }} <a href="https://github.com/AlmaLinux/almalinux-deploy">{{ i18n "AlmaLinux-deploy" }}<a> {{ " you can migrate to AlmaLinux in-place. If you are coming from CentOS 7, or need to upgrade between major versions, " }} <a href="https://almalinux.org/elevate">{{ i18n "ELevate" }}</a> {{ i18n " (developed and maintained by the AlmaLinux Community) allows you to migrate to, and upgrade AlmaLinux in-place." }}
+                                {{ i18n "Switching Linux distros can be a headache, but that is not the case when switching from CentOS to AlmaLinux OS. Using " }} <a href="https://github.com/AlmaLinux/almalinux-deploy">{{ i18n "AlmaLinux-deploy" }}<a> {{ " you can migrate to AlmaLinux in-place. If you are coming from CentOS 7, or need to upgrade between major versions, " }} <a href="{{ "elevate" | relLangURL }}">{{ i18n "ELevate" }}</a> {{ i18n " (developed and maintained by the AlmaLinux Community) allows you to migrate to, and upgrade AlmaLinux in-place." }}
                             </div>
                         </div>
                     </div>
@@ -718,7 +718,7 @@
                             <div class="accordion-body">
                                 {{ i18n "Since AlmaLinux is binary compatible with RHEL®, your applications and services should be completely interoperable. You can rapidly migrate any number of servers using " }}<a href="https://github.com/AlmaLinux/almalinux-deploy">{{ i18n "AlmaLinux-deploy." }}<a>
 
-                                {{ i18n "If you are using CentOS 7 or 8 and need help upgrading and migrating, check out" }} <a href="https://almalinux.org/elevate">{{ i18n "ELevate." }}</a> 
+                                {{ i18n "If you are using CentOS 7 or 8 and need help upgrading and migrating, check out" }} <a href="{{ "elevate" | relLangURL }}">{{ i18n "ELevate." }}</a> 
                             </div>
                         </div>
                     </div>

--- a/layouts/members/single.html
+++ b/layouts/members/single.html
@@ -26,7 +26,7 @@
                             {{ i18n "The AlmaLinux Foundation is the entity behind AlmaLinux OS, the forever-free Enterprise-grade Linux distribution." }} {{ i18n "As a member, you will have a voice in the direction of the project, and can vote for and be voted into the Board of Directors by other members." }} {{ i18n "There are several pathways available for becoming a member, including project contributors, mirror maintainers/sponsors and service providers to the community, as well as official sponsors for the project." }}
                         </p>
                         <p>
-                            {{ i18n "The acceptance of each application will be reviewed on a case-by-case basis by the " }} <a href="/p/membership-committee/" class="al-laws-link"> <b>{{ i18n "Membership Committee" }}</b> </a> {{ i18n ", in accordance with the " }} <a href="/p/foundation-bylaws/" class="al-laws-link"> <b>{{ i18n "Bylaws" }}</b> </a> {{ i18n " established by the Board." }}                        </p>
+                            {{ i18n "The acceptance of each application will be reviewed on a case-by-case basis by the " }} <a href="{{ "p/membership-committee/" | relLangURL }}" class="al-laws-link"> <b>{{ i18n "Membership Committee" }}</b> </a> {{ i18n ", in accordance with the " }} <a href="{{ "p/foundation-bylaws/" | relLangURL }}" class="al-laws-link"> <b>{{ i18n "Bylaws" }}</b> </a> {{ i18n " established by the Board." }}                        </p>
                         <p>
                             {{ i18n "Membership guidelines are" }} <a href="https://lnx.rocks/sponsormembers" class="al-guideline-link" target="_blank"> <b>{{ i18n "available here" }}</b> </a>
                         </p>

--- a/layouts/partials/common/nav.html
+++ b/layouts/partials/common/nav.html
@@ -14,7 +14,7 @@
 <nav id="al-primary-navbar" class="al-primary-navbar navbar p-0 sticky-top navbar-expand-lg navbar-dark flex-column with-motd">
 
     <div class="container  my-3">
-        <a class="navbar-brand" href="/">
+        <a class="navbar-brand" href="{{ "" | relLangURL }}">
             <img src="/images/logo.svg" alt="AlmaLinux OS logo" width="165.93" height="32">
         </a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#main-navbar" aria-controls="main-navbar" aria-expanded="false" aria-label="Toggle navigation">

--- a/layouts/security/single.html
+++ b/layouts/security/single.html
@@ -163,7 +163,7 @@
               <p>
                 {{ i18n "The Software Bill of Materials (SBOM) provides a comprehensive list of third-party and open-source components in a codebase, including version numbers, licensing information, and potential vulnerabilities." }}
                 {{ i18n "AlmaLinux Build System has implemented SBOM into its pipeline for security purposes, such as tracing the build process, making it more secure, and reducing the risk of data corruption. " }}
-                <a href="/sbom">{{ i18n "Read more" }}</a> 
+                <a href="{{ "sbom" | relLangURL }}">{{ i18n "Read more" }}</a> 
                 {{ i18n "about SBOM integration in AlmaLinux." }}<br>
                 {{ i18n "AlmaLinux OS also provides " }}
                 <a href="https://wiki.almalinux.org/documentation/sbom-guide.html">{{ i18n "AlmaLinux SBOM User Guide" }}</a>


### PR DESCRIPTION
Specifying a direct path causes the language selection to be lost.

e.g., https://almalinux.org/ja/contribute/ => 「会員になる」 => https://almalinux.org/members/