### PR TITLE
Added YouTube shortcode width and height functionality

### DIFF
--- a/content/blog/2023-12-14-2023-highlights.md
+++ b/content/blog/2023-12-14-2023-highlights.md
@@ -29,7 +29,7 @@ As always, your feedback helps make these releases successful! You can help by t
 
 In case you missed it, Red Hat announced this year that they will no longer be providing the means for downstream clones to continue to be 1:1 binary copies of RHEL. As a result, we are now promising RHEL compatibility, rather than being an exact copy of RHEL. Watch the Q&A video below or on [Piped](https://piped.video/watch?v=DNMnajmyLaA) to learn more about what this means. You can also [read more in this blog post](https://almalinux.org/blog/future-of-almalinux/)!
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/DNMnajmyLaA?si=8zE5H90evplzV8-t" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+{{< youtube id="DNMnajmyLaA" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 As a result of this change we have introduced [new repositories for AlmaLinux](https://almalinux.org/blog/new-repositories-for-almalinux-os-synergy-and-testing/), and have been able to ship critical security and bug fixes sooner than any other enterprise linux distro. Below, I've included a few of the most critical exploits we've seen, and the timelines. In some cases, any distribution that is still relying on RHEL as their upstream is still waiting for these patches to be released.
 

--- a/content/blog/2024-01-16-video-contributions.md
+++ b/content/blog/2024-01-16-video-contributions.md
@@ -16,7 +16,7 @@ post:
 
 To address some of the common community questions that we are getting, we are excited to share that we will be creating short Q&A videos that will be shared on some of our most common outreach platforms. You may have seen the first of these videos shared on our channels in November, which was a short conversation between Andrew and I.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/DNMnajmyLaA?si=8zE5H90evplzV8-t" title="AlmaLinux Binary Compatibility Q & A" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+{{< youtube id="DNMnajmyLaA" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 ## Want to get involved?
 

--- a/content/blog/2024-02-01-aldt-recap.md
+++ b/content/blog/2024-02-01-aldt-recap.md
@@ -25,7 +25,7 @@ language: english with translations to Japanese
 
 We kicked off the day with me presenting a bit about how AlmaLinux got started and what we’ve been up to since then, to make sure that everyone attending had the same base understanding to start with. 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Hxwhw6Q6ITc?si=0DhpLH-gcq6gH88h" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="max-width: 100%;"></iframe>
+{{< youtube id="Hxwhw6Q6ITc" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 ### The Real Backstory of the Enterprise Linux Community 
 <em>Igor Seletskiy - CEO @ Tuxcare Inc.</em><br />
@@ -33,7 +33,7 @@ language: english with translations to Japanese
 
 Igor Seletskiy followed me and took us through the history of enterprise linux starting all the way back in 1993, and discussed the love that he has for the enterprise linux ecosystem.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/hii46o6Vnw0?si=UxoZzme5kXJrOkDB" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="max-width: 100%"></iframe>
+{{< youtube id="hii46o6Vnw0" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 ### AlmaLinux Community Activities in Japan 
 <em>Yohei Suzuki - Cybertrust Japan</em><br />
@@ -41,7 +41,7 @@ language: Japanese
 
 Yohei Suzuki wrapped up our keynotes by sharing the efforts that he and our partners at Cybertrust have been helping us with in Japan.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/W7wfkk4rGMw?si=raMNLPHRG_pyi1oy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="max-width: 100%"></iframe>
+{{< youtube id="W7wfkk4rGMw" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 ### Building AlmaLinux OS 
 <em>Andrew Lukoshko - AlmaLinux OS Architect @ CloudLinux</em><br />
@@ -49,7 +49,7 @@ language: english with translations to Japanese
 
 Andrew Lukushko kicked off one of our technical tracks discussing how we go about building AlmaLinux OS in detail. He covered everything from how we decide where to get our code, to how we build our images.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/GVIt_7kpUiw?si=e00R2z_ZFG-U3se3" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="max-width: 100%"></iframe>
+{{< youtube id="GVIt_7kpUiw" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 ### The Evolution of SBOMs in AlmaLinux 
 <em>Matthias Kruk - AlmaLinux and MIRACLE LINUX Developer @ Cybertrust Japan</em><br />
@@ -57,23 +57,22 @@ language: Japanese
 
 Matthias Kruk has been working on our SBOM support for quite a while, and he covered a lot of the history and where the community might take the implementation next.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/RJRKqY64xCo?si=-rSSgAXyYsxyzZrM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="max-width: 100%"></iframe>
-
+{{< youtube id="RJRKqY64xCo" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 ### The Forefront of AlmaLinux on ARM: AlmaLinux 9 on the HPE ProLiant RL300 Gen11 Server
 <em>Masazumi Koga - OpenSource/Linux Technology Evangelist @ Hewlett Packard Japan, G.K.</em><br />
 
 Masazumi Koga presents for us the use of AlmaLinux on an HPE server, and showcases the ease with which he is able to install and configure AlmaLinux for the use case. 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/AcOl-AdyRoM?si=AkbrArvH8pJ5IP0T" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="max-width: 100%"></iframe>
+{{< youtube id="AcOl-AdyRoM" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 ### Seamless Migration: Transitioning from CentOS 7 to AlmaLinux
 <em>Kimiyoshi Ohno - OSS Laboratory general manager @ DesigNET Inc.</em><br />
 language: Japanese
 
-Kimiyoshi Ohno's presentation takes us through the entire process of moving to AlmaLinux, including a discussion of why you should choose AlmaLinux and case studies of the transition. 
+Kimiyoshi Ohno's presentation takes us through the entire process of moving to AlmaLinux, including a discussion of why you should choose AlmaLinux and case studies of the transition.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/AEA8losuKsA?si=RVl7s3uwZaY-HlZH" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="max-width: 100%"></iframe>
+{{< youtube id="AEA8losuKsA" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 ## Up Next: AlmaLinux Day: Germany
 
@@ -92,7 +91,7 @@ In case you aren't already familiar with CloudFest, this is their description:
 
 > The world’s largest cloud industry event is ready to once again take over a spectacular European amusement park to facilitate new partnerships, deep knowledge sharing, and the best parties the industry has ever seen. We do this because we love technology, we love people, and we’re excited for the possibilities that emerge when brilliant human beings connect.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/8D04ftA6o0U?si=DCw1zFkqxsnNOksh" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="max-width: 100%"></iframe>
+{{< youtube id="8D04ftA6o0U" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 ## Even more events this year!
 

--- a/content/blog/2024-02-29-feb-event-recap.md
+++ b/content/blog/2024-02-29-feb-event-recap.md
@@ -19,7 +19,7 @@ Earlier this month, we had three back-to-back events: CentOS Connect, FOSDEM, an
 
 CentOS Connect is always a great place for us to connect with the folks most invested in one of our favorite upstream projects. We met tons of people and learned a ton! At this year's event our Cloud and Virt Team Lead Elkhan Mammadli was able to share a talk about how we automated testing here at AlmaLinux with openQA and Testinfra. The talk was recorded, so you can watch it yourself!
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/HgZKLs5ItH4?si=cvzYgbjZurFP0EIR" title="Elkhan Mammadli: AlmaLinux: How we automated testing without inventing the wheel and instead improving it" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen style="max-width: 100%;"></iframe>
+{{< youtube id="HgZKLs5ItH4" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 You can watch the rest of the amazing sessions on the CentOS Youtube channel. [Here's the link to the full playlist](https://www.youtube.com/watch?v=vwA4mULGiF8&list=PLuRtbOXpVDjA30Q8EQzJBjfl0gCFo8vpK)!
 

--- a/content/blog/2024-05-01-almalinux-day-germany-recap.md
+++ b/content/blog/2024-05-01-almalinux-day-germany-recap.md
@@ -34,7 +34,7 @@ The opening keynote for AlmaLinux Day: Germany shows us where AlmaLinux came fro
 * Jonas Trüstedt - Senior Orcharhino Architect, ATIX AG
 * Tristan Theroux - IT Infrastructure & Security Director, SHED
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/P9pO0fPGVeo?si=P1rxAe4LWHywXQq2" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+{{< youtube id="P9pO0fPGVeo" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 language: English
 
@@ -54,7 +54,7 @@ Finding our footing without using Red Hat Enterprise Linux has been an exciting 
 
 #### Speaker: Andrew Lukoshko - Release Engineering Lead, AlmaLinux
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/aMvI5E9-LYI?si=O0bGPgYavKHagx1b" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+{{< youtube id="aMvI5E9-LYI" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 language: English
 
@@ -82,7 +82,7 @@ In this panel, we get to hear from some of the board members about things that t
 * Jesse Asklund - Chief Experience Officer, WebPros
 * Alex Iribarren - Leader Of Cloud IAAS And Linux Platform Engineering Teams, CERN
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/PP3OPvmUwTs?si=47Kuq4JxpfzlXkSC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+{{< youtube id="PP3OPvmUwTs" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 language: English
 

--- a/content/blog/2024-05-06-announcing-94-stable.md
+++ b/content/blog/2024-05-06-announcing-94-stable.md
@@ -34,7 +34,7 @@ Torrents are available as well at:
 
 Matching release and software versions with Red Hat Enterprise Linux(RHEL), AlmaLinux builds from the same sources as RHEL, promises complete compatibility with RHEL, and does so from freely available open source code. This makes it the only choice for anyone looking for a truly open source Enterprise Linux. If you are looking for a deeper undertanding of how AlmaLinux is built, watch this 23 minute video of our Lead Architect explaining in detail at [AlmaLinux Day: Germany](https://almalinux.org/almalinux-day-germany-2024/), earlier this year.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/aMvI5E9-LYI?si=8x_HvLo-aSIo5zpM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+{{< youtube id="aMvI5E9-LYI" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
 
 ## ISOs, Live Images, Cloud and Containers
 

--- a/contributing-blog-posts.md
+++ b/contributing-blog-posts.md
@@ -54,7 +54,28 @@ post:
 **The meat of your post**
 
 - Below the --- of the metadata block, you should place the content of your blog post. This content should be in markdown format, and any images you want to include in your post can be added to `./static/blog-images/` and will serve from `/blog-images/`.
-- Before submitting your PR, please test that your content loads correctly by building the site locally with the command `hugo serve`
+- Before submitting your PR, please test that your content loads correctly by building the site locally with the command `hugo server`
+- Adding YouTube embeds:\
+  To emebed YouTube videos we suggest you use the [YouTube shortcode](https://gohugo.io/content-management/shortcodes/#youtube) supplied by Hugo and modified by our contributors to include height and width customization with better mobile support, here is an overview of how to use it:
+  - **YouTube ID** - The youtube ID can be allocated from the video link, for example in this video `https://www.youtube.com/watch?v=dQw4w9WgXcQ`, the ID is `dQw4w9WgXcQ`. (the value of "v" is the video ID)
+  - `allowFullScreen=true` - Whether the video can activate full screen mode.
+  - `autoplay=false` - Whether to automatically play the video. Forces mute to be true.
+  - `class` - The class attribute of the wrapping div element. Specifying removes style attributes from the iframe and its wrapping div.
+  - `controls=true` - Whether to display the video controls.
+  - `end` - The time, in seconds from the video start, when the player should stop playing.
+  - `id` - The video id. Optional if provided as the first positional argument.
+  - `loading=eager` - The loading attribute of the iframe.
+  - `loop=false` - Whether to indefinitely repeat the video. Ignores start and end after the first play.
+  - `mute=false` - Whether to mute the video. Always true when autoplay is true.
+  - `start` - The time, in seconds from the video start, when the player should start playing.
+  - `title` - The title attribute of the iframe element. Defaults to "YouTube video".
+  - `width` - The width of the video, specified in px, %, vw, em, rem, cm, in, mm, pt, or pc.
+  - `height` - The height of the video, specified in px, %, vh, em, rem, cm, in, mm, pt, or pc.
+
+  For example:
+  ```html
+  {{< youtube id="Video ID" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="I love AlmaLinux" >}}
+  ```
 
 
 ### Some notes about content

--- a/layouts/shortcodes/youtube.html
+++ b/layouts/shortcodes/youtube.html
@@ -1,0 +1,150 @@
+{{- /*
+    Renders an embedded YouTube video.
+    
+    @param {bool} [allowFullScreen=true] Whether the iframe element can activate full screen mode.
+    @param {bool} [autoplay=false] Whether to automatically play the video. Forces mute to be true.
+    @param {string} [class] The class attribute of the wrapping div element. When specified, removes the style attributes from the iframe element and its wrapping div element.
+    @param {bool} [controls=true] Whether to display the video controls.
+    @param {int} [end] The time, measured in seconds from the start of the video, when the player should stop playing the video.
+    @param {string} [id] The video id. Optional if the id is provided as first positional argument.
+    @param {string} [loading=eager] The loading attribute of the iframe element.
+    @param {bool} [loop=false] Whether to indefinitely repeat the video. Ignores the start and end arguments after the first play.
+    @param {bool} [mute=false] Whether to mute the video. Always true when autoplay is true.
+    @param {int} [start] The time, measured in seconds from the start of the video, when the player should start playing the video.
+    @param {string} [title] The title attribute of the iframe element. Defaults to "YouTube video".
+    @param {string} [width="100%"] The width of the video.
+    @param {string} [height="56.25%"] The height of the video.
+    
+    @returns {template.HTML}
+    
+    @reference https://developers.google.com/youtube/player_parameters
+    
+    @example {{< youtube 0RKpf3rK57I >}}
+    @example {{< youtube id=0RKpf3rK57I loading=lazy start=30 >}}
+    */}}
+    
+    {{- $pc := .Page.Site.Config.Privacy.YouTube }}
+    {{- $remoteErrID := "err-youtube-remote" }}
+    {{- if not $pc.Disable }}
+      {{- with $id := or (.Get "id") (.Get 0) }}
+    
+        {{/* Set defaults. */}}
+        {{- $allowFullScreen := "allowfullscreen" }}
+        {{- $autoplay := 0 }}
+        {{- $class := "" }}
+        {{- $controls := 1 }}
+        {{- $end := 0 }}
+        {{- $loading := "eager" }}
+        {{- $loop := 0 }}
+        {{- $mute := 0 }}
+        {{- $start := 0 }}
+        {{- $title := "YouTube video" }}
+        {{- $width := "100%" }}
+        {{- $height := "56.25%" }}
+    
+        {{- /* Get arguments. */}}
+        {{- if in (slice "false" false 0) ($.Get "allowFullScreen") }}
+          {{- $allowFullScreen = "" }}
+        {{- else if in (slice "true" true 1) ($.Get "allowFullScreen") }}
+          {{- $allowFullScreen = "allowfullscreen" }}
+        {{- end }}
+        {{- if in (slice "false" false 0) ($.Get "autoplay") }}
+          {{- $autoplay = 0 }}
+        {{- else if in (slice "true" true 1) ($.Get "autoplay") }}
+          {{- $autoplay = 1 }}
+        {{- end }}
+        {{- if in (slice "false" false 0) ($.Get "controls") }}
+          {{- $controls = 0 }}
+        {{- else if in (slice "true" true 1) ($.Get "controls") }}
+          {{- $controls = 1 }}
+        {{- end }}
+        {{- if in (slice "false" false 0) ($.Get "loop") }}
+          {{- $loop = 0 }}
+        {{- else if in (slice "true" true 1) ($.Get "loop") }}
+          {{- $loop = 1 }}
+        {{- end }}
+        {{- if in (slice "false" false 0) ($.Get "mute") }}
+          {{- $mute = 0 }}
+        {{- else if or (in (slice "true" true 1) ($.Get "mute")) $autoplay }}
+          {{- $mute = 1 }}
+        {{- end }}
+        {{- $class := or ($.Get "class") $class }}
+        {{- $end := or ($.Get "end") $end }}
+        {{- $loading := or ($.Get "loading") $loading }}
+        {{- $start := or ($.Get "start") $start }}
+        {{- $title := or ($.Get "title") $title }}
+        {{- $width := or ($.Get "width") $width }}
+        {{- $height := or ($.Get "height") $height }}
+    
+        {{- /* Determine host. */}}
+        {{- $host := cond $pc.PrivacyEnhanced "www.youtube-nocookie.com" "www.youtube.com" }}
+    
+        {{- /* Set styles. */}}
+        {{- $divStyle := printf "position: relative; width: %s; padding-bottom: %s; height: 0; overflow: hidden;" $width $height }}
+        {{- $iframeStyle := "position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" }}
+        {{- if $class }}
+          {{- $iframeStyle = "" }}
+        {{- end }}
+    
+        {{- /* Set class or style of wrapping div element. */}}
+        {{- $divClassOrStyle := printf "style=%q" $divStyle }}
+        {{- with $class }}
+          {{- $divClassOrStyle = printf "class=%q" $class }}
+        {{- end }}
+    
+        {{- /* Define src attribute. */}}
+        {{- $src := printf "https://%s/embed/%s" $host $id }}
+        {{- $params := dict
+          "autoplay" $autoplay
+          "controls" $controls
+          "end" $end
+          "mute" $mute
+          "start" $start
+          "loop" $loop
+        }}
+        {{- if $loop }}
+          {{- $params = merge $params (dict "playlist" $id) }}
+        {{- end }}
+        {{- $s := slice }}
+        {{- range $k, $v := $params }}
+          {{- $s = $s | append $k }}
+          {{- $s = $s | append $v }}
+        {{- end }}
+        {{- with querify $s }}
+          {{- $src = printf "%s?%s" $src . }}
+        {{- end }}
+    
+        {{- /* Set iframe attributes. */}}
+        {{- $iframeAttributes := dict
+          "allow" "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          "allowfullscreen" $allowFullScreen
+          "loading" $loading
+          "referrerpolicy" "strict-origin-when-cross-origin"
+          "src" $src
+          "style" $iframeStyle
+          "title" $title
+        }}
+    
+        {{- /* Render. */}}
+        <div data-role="yt-embed" {{ $divClassOrStyle | safeHTMLAttr }}>
+          <iframe
+            {{- range $k, $v := $iframeAttributes }}
+              {{- if $v }}
+                {{- printf " %s=%q" $k $v | safeHTMLAttr }}
+              {{- end }}
+            {{- end }}
+          ></iframe>
+        </div>
+      {{- else }}
+        {{- errorf "The %q shortcode requires an id argument. See %s" .Name .Position }}
+      {{- end }}
+    {{- end }}
+    
+    <style>
+      @media screen and (max-width: 991px) {
+        [data-role="yt-embed"] {
+          min-width: 90%;
+          padding-bottom: calc(90% * 9 / 16) !important;
+        }
+      }
+    </style>


### PR DESCRIPTION
I added a modified version of the [shortcode for YouTube embeds](https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/shortcodes/youtube.html) and updated all pages using iframes to use the shortcode.

These are the pages I modified:
|Link                                                              |Changed?|
|------------------------------------------------------------------|--------|
|https://almalinux.org/blog/2023-12-14-2023-highlights/            |Yes     |
|https://almalinux.org/blog/2024-01-16-video-contributions/        |Yes     |
|https://almalinux.org/blog/2024-05-06-announcing-94-stable/       |Yes     |
|https://almalinux.org/blog/2024-05-01-almalinux-day-germany-recap/|Yes     |
|https://almalinux.org/blog/2024-02-29-feb-event-recap/            |Yes     |
|https://almalinux.org/blog/2024-02-01-aldt-recap/                 |Yes     |

The shortcode now can be used to set the height and width of an iframe, and with the help of @mattlasheboro I also added better support for mobile users.

This is the general syntax to use the shortcode:
```html
{{< youtube id="AEA8losuKsA" width="45%" height="25%" autoplay="false" controls="true" mute="false" title="YouTube video player" >}}
```

---

This PR is to solve this [issue](https://github.com/AlmaLinux/almalinux.org/issues/564).