### PR TITLE
Updates to the downloads page

### DIFF
--- a/layouts/get-almalinux/single.html
+++ b/layouts/get-almalinux/single.html
@@ -370,7 +370,7 @@
                         </div>
                       </div>
                       <div class="itemAl_02" style="padding-left: 20px; width: 608px; margin-top: 15px;">
-                        <b><a href="https://repo.almalinux.org/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.10-20240530.x86_64.qcow2">AlmaLinux OS 8.10 BIOS</a></b>
+                        <b><a href="https://repo.almalinux.org/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.10-20240530.x86_64.qcow2">AlmaLinux OS 8.10</a></b>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px; margin-bottom: 20px;">
                           <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
@@ -379,17 +379,7 @@
                             </div>
                             <input class="put-text_copy" id="text_copy" style="margin-left: 10px; font-family: monospace; font-size: 14px; width: 539px; padding: 0; background: none; border: none; color: #fff; outline: none;" type="text" value="41a6bcdefb35afbd2819f0e6c68005cd5e9a346adf2dc093b1116a2b7c647d86" readonly>
                           </div>
-                        </div>
-                        <b><a href="https://repo.almalinux.org/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-UEFI-latest.x86_64.qcow2">AlmaLinux OS 8.10 UEFI</a></b>
-                        <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
-                          <div style="display: flex; flex-direction: column;">
-                            <div class="Sha_button" style="display: flex; justify-content: space-between;">
-                              <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
-                            </div>
-                            <input class="put-text_copy" id="text_copy" style="margin-left: 10px; font-family: monospace; font-size: 14px; width: 539px; padding: 0; background: none; border: none; color: #fff; outline: none;" type="text" value="41a6bcdefb35afbd2819f0e6c68005cd5e9a346adf2dc093b1116a2b7c647d86" readonly>
-                          </div>
-                        </div>
+                        </div>                        
                         <div class="Link-Downloads-Al" style="display: flex; margin-top: 20px;">
                           <div class="itemAl_01" style="width: 200px;">
                             <b><a href="https://mirrors.almalinux.org" style="display:inline-block; margin-right:20px;">{{ i18n "Download from mirrors" }}</a></b>
@@ -1322,7 +1312,7 @@
                         <b><a href="https://repo.almalinux.org/rpi/9/images/">AlmaLinux OS 9.4</a></b>
                       </div>
                       <div class="itemAl_02"  style="margin-left: 100px;">
-                        <b><a href="https://repo.almalinux.org/rpi/images/">AlmaLinux OS 8</a></b>
+                        <b><a href="https://repo.almalinux.org/rpi/images/">AlmaLinux OS 8.10</a></b>
                       </div>
                     </div>
                     <p style="margin-bottom: 0px;">


### PR DESCRIPTION
- Unified Generic Cloud links for 8.10 x86_64 since the images have hybrid boot and the download URLs of the UEFI images are symlinked to the current image (same as for 9.4)
- Updated Raspberry Pi 8 version to 8.10