### PR TITLE
Replacing absolute links with relative

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -83,7 +83,7 @@
                             <i class="bi bi-people pe-1"></i>
                             {{ i18n "Contribute" }}
                         </a>
-                        <a href="{{ "/get-almalinux" | absLangURL }}" class="btn btn-lg px-4 al-hero-cta-secondary">
+                        <a href="{{ "/get-almalinux" | relLangURL }}" class="btn btn-lg px-4 al-hero-cta-secondary">
                             <i class="bi bi-download pe-1"></i>
                             {{ i18n "Download" }}
                         </a>

--- a/layouts/partials/common/footer.html
+++ b/layouts/partials/common/footer.html
@@ -15,9 +15,9 @@
                     <li><a href="https://github.com/AlmaLinux/">GitHub</a></li>
                     <li><a href="https://bugs.almalinux.org/">{{ i18n "Bugs" }}</a></li>
                     <li><a href="https://repo.almalinux.org/">{{ i18n "Repository" }}</a></li>
-                    <li><a href="{{ "/get-almalinux" | absLangURL }}">{{ i18n "Downloads" }}</a></li>
-                    <li><a href="{{ "/members" | absLangURL }}">{{ i18n "Membership" }}</a></li>
-                    <li><a href="{{ "/elevate" | absLangURL }}">ELevate</a></li>
+                    <li><a href="{{ "/get-almalinux" | relLangURL }}">{{ i18n "Downloads" }}</a></li>
+                    <li><a href="{{ "/members" | relLangURL }}">{{ i18n "Membership" }}</a></li>
+                    <li><a href="{{ "/elevate" | relLangURL }}">ELevate</a></li>
                     <li><a href="https://lists.almalinux.org/">{{ i18n "Mailing Lists" }}</a></li>
                     <li><a href="https://status.almalinux.org/">{{ i18n "Status Page" }}</a></li>
                     <li><a href="https://openqa.almalinux.org/">{{ i18n "openQA" }}</a></li>

--- a/layouts/partials/common/nav.html
+++ b/layouts/partials/common/nav.html
@@ -109,7 +109,7 @@
                     </ul>
                 </li>
                 <li class="nav-item ps-md-2">
-                    <a class="nav-link btn btn al-download-button" href="{{ "/get-almalinux" | absLangURL }}">
+                    <a class="nav-link btn btn al-download-button" href="{{ "/get-almalinux" | relLangURL }}">
                         <i class="bi bi-download pe-1 d-none d-xl-inline"></i>
                         {{ i18n "Download" }}
                     </a>


### PR DESCRIPTION
Following our latest discussion with Cody, replacing the absolute links to the Get AlmaLinux page with relative. Noticed the same issue with Membership and ELevate, so also replacing them. 