### PR TITLE
Commercial support layout

### DIFF
--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -71,7 +71,7 @@ padding-right: 15px !important;
 .al-page-index .al-hero-cta-tertiary:hover {
   background: #f8c100;
 }
-.al-page-index .al-index-feature-container {
+.al-page-index .al-index-feature-container, .al-commercial-supporter-list {
   background: #0e3b5c;
 }
 .al-page-index .al-index-feature-container .al-index-feature-icon {

--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -108,9 +108,9 @@ padding-right: 15px !important;
 }
 
 .al-index-community-content-wrap p{
- 
+
   flex: 1;
- 
+
 }
 .al-page-index .al-index-community-container .al-community-cta {
   min-width: 120px;
@@ -131,7 +131,7 @@ border-bottom-color: #14598a !important;
 .al-backed-by-list a{
   margin-top: 3rem !important;
 }
-/* formatting the sponsor logos on the home page. */ 
+/* formatting the sponsor logos on the home page. */
  .al-page-index .al-index-backed-by .al-backed-by-list {
   justify-content: space-between;
   padding: 0;
@@ -147,7 +147,7 @@ border-bottom-color: #14598a !important;
   width: 120px;
 }
 
-/* formatting the sponsors on the event pages. */ 
+/* formatting the sponsors on the event pages. */
 .al-page-index .al-index-sponsors .al-backed-by-list {
   justify-content: center;
   padding: 0;
@@ -168,7 +168,7 @@ border-bottom-color: #14598a !important;
   width: 70px;
 }
 
-/* formatting the commercial support vendors on the index page. */ 
+/* formatting the commercial support vendors on the index page. */
 .al-page-index .al-index-commercial-support p.border-bottom {
   border-bottom-color: #14598a !important;
 }
@@ -178,7 +178,7 @@ border-bottom-color: #14598a !important;
 .al-page-index .al-index-commercial-support .al-commercial-supporter-list div.col {
   text-align: center;
 }
-.al-page-index .al-index-commercial-support .al-commercial-supporter-list .al-commercial-supporter-logo-container {
+.al-page-index .al-index-commercial-support .al-commercial-supporter-list {
   height: 100%;
 }
 .al-page-index .al-index-commercial-support .al-commercial-supporter-list .al-commercial-supporter-logo {
@@ -188,6 +188,11 @@ border-bottom-color: #14598a !important;
 .al-commercial-supporter-list {
 	margin-top: 40px;
 }
+
+.al-commercial-supporter-logo-container {
+  background: #082336;
+}
+
 .al-page-index .al-index-faq {
   background: #0e3b5c;
 }
@@ -230,11 +235,11 @@ padding: 0px !important;
   color: #fefefe;
 }
 .itemsOff {
-  height: 36px; 
+  height: 36px;
   margin: 15px 0 15px 0;
 }
 .itemsTr {
-  height: 72px; 
+  height: 72px;
   margin: 15px 0 15px 0;
 }
 .al-page-index .al-index-newsletter a {
@@ -595,7 +600,7 @@ outline: none !important;
 .al-primary-navbar .nav-link.al-download-button:hover {
   color: black !important;
   background: #79cb24;
- 
+
 }
 .al-primary-navbar .nav-link {
   padding-left: 1rem !important;
@@ -932,7 +937,7 @@ pre > code {
 .pagination .disabled {
 
   color: #000 !important;
-  
+
 }
 
 .highlight > pre {

--- a/assets/scss/home.css
+++ b/assets/scss/home.css
@@ -26,7 +26,7 @@
 .al-page-index .al-hero-cta-tertiary:hover {
   background: #f8c100;
 }
-.al-page-index .al-index-feature-container {
+.al-page-index .al-index-feature-container, .al-commercial-supporter-list {
   background: #0e3b5c;
 }
 .al-page-index .al-index-feature-container .al-index-feature-icon {

--- a/assets/scss/home.css
+++ b/assets/scss/home.css
@@ -97,7 +97,7 @@
 .al-page-index .al-index-commercial-support .al-commercial-supporter-list div.col {
   text-align: center;
 }
-.al-page-index .al-index-commercial-support .al-commercial-supporter-list .al-commercial-supporter-logo-container {
+.al-page-index .al-index-commercial-support .al-commercial-supporter-list {
   height: 100%;
 }
 .al-page-index .al-index-commercial-support .al-commercial-supporter-list .al-commercial-supporter-logo {

--- a/assets/scss/home.css
+++ b/assets/scss/home.css
@@ -103,6 +103,11 @@
 .al-page-index .al-index-commercial-support .al-commercial-supporter-list .al-commercial-supporter-logo {
   max-width: 120px;
   width: 100%;
+
+}
+
+.al-commercial-supporter-logo {
+  max-height: 100px !important;
 }
 .al-page-index .al-index-faq {
   background: #0e3b5c;

--- a/assets/scss/home.scss
+++ b/assets/scss/home.scss
@@ -146,6 +146,7 @@
       .al-commercial-supporter-logo {
         max-width: 120px;
         width: 100%;
+        max-height: 100px;
 
       }
     }

--- a/assets/scss/home.scss
+++ b/assets/scss/home.scss
@@ -146,6 +146,7 @@
       .al-commercial-supporter-logo {
         max-width: 120px;
         width: 100%;
+
       }
     }
   }

--- a/assets/scss/home.scss
+++ b/assets/scss/home.scss
@@ -80,7 +80,7 @@
     }
 
 
-    
+
     .al-community-cta {
       min-width: 120px;
     }
@@ -100,30 +100,30 @@
       border-bottom-color: lighten($al-body-background, 8%) !important;
     }
 
-   
+
     .al-backed-by-list {
       justify-content: space-between;
       padding: 0 !important;
-      
+
       a{
         margin-top: 3rem !important;
-      
+
 
       div.col {
         text-align: center;
       }
-     
+
 
       .al-backer-logo-container {
         height: 100%;
-        
-      
+
+
       }
 
       .al-backer-logo {
         height: 100%;
         width:120px;
-       
+
       }
     }
     }
@@ -134,17 +134,13 @@
       border-bottom-color: lighten($al-body-background, 8%) !important;
     }
 
-    
+
 
     .al-commercial-supporter-list {
       justify-content: center;
 
       div.col {
         text-align: center;
-      }
-
-      .al-commercial-supporter-logo-container {
-        height: 100%;
       }
 
       .al-commercial-supporter-logo {
@@ -215,7 +211,7 @@
   .al-index-press {
     background: #0e3b5c;
 
-   
+
 
     .al-index-press-item {
       margin-bottom: 10px;
@@ -234,7 +230,7 @@
           content: close-quote;
           padding-left: 3px;
         }
- 
+
         &:before,
         &:after {
           font-family: $al-font-family-accent;

--- a/assets/scss/main.css
+++ b/assets/scss/main.css
@@ -26,7 +26,7 @@
 .al-page-index .al-hero-cta-tertiary:hover {
   background: #f8c100;
 }
-.al-page-index .al-index-feature-container {
+.al-page-index .al-index-feature-container, .al-commercial-supporter-list {
   background: #0e3b5c;
 }
 .al-page-index .al-index-feature-container .al-index-feature-icon {

--- a/assets/scss/main.css
+++ b/assets/scss/main.css
@@ -97,10 +97,10 @@
 .al-page-index .al-index-commercial-support .al-commercial-supporter-list div.col {
   text-align: center;
 }
-.al-page-index .al-index-commercial-support .al-commercial-supporter-list .al-commercial-supporter-logo-container {
+.al-page-index .al-index-commercial-support .al-commercial-supporter-list {
   height: 100%;
 }
-.al-page-index .al-index-commercial-support .al-commercial-supporter-list .al-commercial-supporter-logo {
+.al-page-index .al-index-commercial-support .al-commercial-supporter-list  {
   max-width: 120px;
   width: 100%;
 }
@@ -585,6 +585,10 @@ button:focus, .btn:focus {
 .al-primary-navbar .al-translate-callout a i {
   margin-right: 0.4rem;
   font-size: 0.8rem;
+}
+
+.al-commercial-supporter-logo-container {
+  background: #082336;
 }
 
 #al-motd {

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -571,10 +571,10 @@
                      <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-2 py-md-5 display-flex justify-space-between">
 				<!-- to add a row, copy everything from 'start' to 'end' in one of the other rows, and update all of the information appropriately. order-md-last in the class of the image div will display the image right-justified instead of left. -->
 				 <!-- start CyberTrust row -->
-                 <div class="row al-commercial-supporter-list rounded col d-flex align-items-start mx-5">
+                 <div class="row al-commercial-supporter-list rounded col d-flex align-items-start mx-5" style="height: 400px !important">
                      <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center p-2 border-none rounded">
 					     <a href="https://www.cybertrust.co.jp/almalinux/">
-                             <img loading="lazy" src="/brands/cybertrust-japan.svg" alt="CyberTrust Japan" class="al-commercial-supporter-logo"  style="max-height: 80px !important;">
+                             <img loading="lazy" src="/brands/cybertrust-japan.svg" alt="CyberTrust Japan" class="al-commercial-supporter-logo"  style="max-height: 70px !important;">
 						 </a>
                      </div>
 					<div class="col-12 col-md-8">
@@ -584,7 +584,7 @@
                 </div>
 				<!-- end CyberTrust row -->
 				 <!-- start Tuxcare row -->
-                 <div class="row al-commercial-supporter-list rounded col d-flex align-items-start">
+                 <div class="row al-commercial-supporter-list rounded col d-flex align-items-start" style="height: 400px !important">
 
                         <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center border-none rounded">
                             <a href="https://tuxcare.com/almalinux-enterprise-support/">
@@ -600,7 +600,7 @@
                 </div>
 				<!-- end Tuxcare row -->
 				<!-- start OpenLogic row -->
-                <div class="row al-commercial-supporter-list col rounded d-flex align-items-start">
+                <div class="row al-commercial-supporter-list col rounded d-flex align-items-start" style="height: 400px !important">
                     <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center rounded p-2 border-none">
 					    <a href="https://www.openlogic.com/solutions/enterprise-linux-support/almalinux">
                             <img loading="lazy" src="/brands/logo-openlogic-tagline-white.svg" alt="OpenLogic" class="al-commercial-supporter-logo">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -568,7 +568,6 @@
 				<p class="text-center pb-2 mb-5">Minimize your risk while getting the most out of your AlmaLinux systems</p>
 				<!-- to add a row, copy everything from 'start' to 'end' in one of the other rows, and update all of the information appropriately. order-md-last in the class of the image div will display the image right-justified instead of left. -->
 				 <!-- start CyberTrust row -->
-                 <div class="d-flex justify-space-between al-commercial-supporter-list mx-md-width-33" >
                      <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-2 py-md-5 display-flex justify-space-between">
 				<!-- to add a row, copy everything from 'start' to 'end' in one of the other rows, and update all of the information appropriately. order-md-last in the class of the image div will display the image right-justified instead of left. -->
 				 <!-- start CyberTrust row -->
@@ -586,14 +585,13 @@
 				<!-- end CyberTrust row -->
 				 <!-- start Tuxcare row -->
                  <div class="row al-commercial-supporter-list rounded col d-flex align-items-start">
-                    <div class="al-commercial-supporter-top">
 
                         <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center border-none rounded">
                             <a href="https://tuxcare.com/almalinux-enterprise-support/">
                                 <img loading="lazy" src="/brands/tuxcare_withtagline.svg" alt="Tuxcare" class="al-commercial-supporter-logo">
                             </a>
                         </div>
-                    </div>
+
                          <div class="col-12 col-md-8">
                              <p>For organizations running AlmaLinux, TuxCare’s Enterprise Support provides extended support for up to 16 years, FIPS-compliant security patches, zero-reboot patching, and much more.</p>
                              <a class="btn btn-primary p-2 rounded text-decoration-none" href="https://tuxcare.com/almalinux-enterprise-support/">Get support</a>
@@ -614,7 +612,6 @@
                      </div>
                  </div>
 				<!-- end OpenLogic row -->
-                     </div>
 
             </div>
         </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -100,7 +100,7 @@
         <!-- COMMUNITY -->
         <div class="al-index-community-container" style="background: #0f4266!important">
             <div class="container al-py-md">
-                <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-2 py-md-5">
+                <div class="row row-cols-1 row-cols-sm-2 row-cols-md-6 row-cols-lg-4 g-4 py-2 py-md-5">
                     <div class="col d-flex align-items-stretch">
                         <i class="bi bi-github al-index-community-icon"></i>
                         <div class="al-index-community-content-wrap">
@@ -564,11 +564,11 @@
 				<p class="text-center pb-2 mb-5">Minimize your risk while getting the most out of your AlmaLinux systems</p>
 				<!-- to add a row, copy everything from 'start' to 'end' in one of the other rows, and update all of the information appropriately. order-md-last in the class of the image div will display the image right-justified instead of left. -->
 				 <!-- start CyberTrust row -->
-                 <div class="row al-commercial-supporter-list">
-                     <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-2 py-md-5">
+                 <div class="display-flex justify-space-between al-commercial-supporter-list">
+                     <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-2 py-md-5 display-flex justify-space-between">
 				<!-- to add a row, copy everything from 'start' to 'end' in one of the other rows, and update all of the information appropriately. order-md-last in the class of the image div will display the image right-justified instead of left. -->
 				 <!-- start CyberTrust row -->
-                 <div class="row al-commercial-supporter-list border rounded col d-flex align-items-start">
+                 <div class="row al-commercial-supporter-list rounded col d-flex align-items-start mx-5">
                      <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center p-2 border-none rounded">
 					     <a href="https://www.cybertrust.co.jp/almalinux/">
                              <img loading="lazy" src="/brands/cybertrust-japan.svg" alt="CyberTrust Japan" class="al-commercial-supporter-logo">
@@ -576,25 +576,29 @@
                      </div>
 					<div class="col-12 col-md-8">
 					    <p>Cybertrust Japan is a provider of a comprehensive security certification services to various public and private entities globally, and offers comprehensive support for AlmaLinux users. Have also produced MIRACLE LINUX for nearly 20 years.</p>
-					    <a class="btn-primary p-2 rounded text-decoration-none"href="https://www.cybertrust.co.jp/almalinux/">Get support</a>
+					    <a class="btn btn-primary p-2 rounded text-decoration-none"href="https://www.cybertrust.co.jp/almalinux/">Get support</a>
                     </div>
                 </div>
 				<!-- end CyberTrust row -->
 				 <!-- start Tuxcare row -->
-                 <div class="row al-commercial-supporter-list border rounded col d-flex align-items-start">
-                     <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center p-2 border-none rounded">
-					     <a href="https://tuxcare.com/almalinux-enterprise-support/">
-                             <img loading="lazy" src="/brands/tuxcare_withtagline.svg" alt="Tuxcare" class="al-commercial-supporter-logo">
-						 </a>
-                     </div>
-					<div class="col-12 col-md-8">
-					    <p>For organizations running AlmaLinux, TuxCare’s Enterprise Support provides extended support for up to 16 years, FIPS-compliant security patches, zero-reboot patching, and much more.</p>
-					    <a class="btn-primary p-2 rounded text-decoration-none" href="https://tuxcare.com/almalinux-enterprise-support/">Get support</a>
+                 <div class="row al-commercial-supporter-list rounded col d-flex align-items-start">
+                    <div class="al-commercial-supporter-top">
+
+                        <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center border-none rounded">
+                            <a href="https://tuxcare.com/almalinux-enterprise-support/">
+                                <img loading="lazy" src="/brands/tuxcare_withtagline.svg" alt="Tuxcare" class="al-commercial-supporter-logo">
+                            </a>
+                        </div>
                     </div>
+                         <div class="col-12 col-md-8">
+                             <p>For organizations running AlmaLinux, TuxCare’s Enterprise Support provides extended support for up to 16 years, FIPS-compliant security patches, zero-reboot patching, and much more.</p>
+                             <a class="btn btn-primary p-2 rounded text-decoration-none" href="https://tuxcare.com/almalinux-enterprise-support/">Get support</a>
+                         </div>
+
                 </div>
 				<!-- end Tuxcare row -->
 				<!-- start OpenLogic row -->
-                <div class="row al-commercial-supporter-list col border rounded d-flex align-items-start">
+                <div class="row al-commercial-supporter-list col rounded d-flex align-items-start">
                     <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center rounded p-2 border-none">
 					    <a href="https://www.openlogic.com/solutions/enterprise-linux-support/almalinux">
                             <img loading="lazy" src="/brands/logo-openlogic-tagline-white.svg" alt="OpenLogic" class="al-commercial-supporter-logo">
@@ -602,7 +606,7 @@
                      </div>
 					 <div class="col-12 col-md-8">
 						<p>Confidently deploy AlmaLinux and all your open source packages with enterprise-grade, 24/7/365 support backed by guaranteed SLAs. Keep your mission-critical apps running smoothly with unlimited tickets and direct access to experienced enterprise architects who put your business first.</p>
-						<a class="btn-primary p-2 rounded text-decoration-none" href="https://www.openlogic.com/solutions/enterprise-linux-support/almalinux">Get support</a>
+						<a class="btn btn-primary p-2 rounded text-decoration-none" href="https://www.openlogic.com/solutions/enterprise-linux-support/almalinux">Get support</a>
                      </div>
                  </div>
 				<!-- end OpenLogic row -->

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -63,7 +63,7 @@
     <section class="al-page-index">
         <!-- HERO -->
         <div class="al-index-container" style="background: #0e3b5c!important;">
-          <div class="container px-0 al-py-lg">  
+          <div class="container px-0 al-py-lg">
             <div class="row flex-lg-row-reverse align-items-center py-2 py-md-5">
                 <div class="d-none d-lg-block col-10 col-sm-8 col-lg-6">
 
@@ -215,7 +215,7 @@
                                 <a href="https://wiki.almalinux.org/cloud/Google.html">Google Cloud</a> <br>
                                 <a href="https://wiki.almalinux.org/cloud/Azure.html">Microsoft Azure</a> <br>
                                 <a href="https://wiki.almalinux.org/cloud/OpenNebula.html">OpenNebula</a> <br>
-                                <a href="https://wiki.almalinux.org/cloud/OCI.html">Oracle Cloud Infrastructure</a> <br>                        
+                                <a href="https://wiki.almalinux.org/cloud/OCI.html">Oracle Cloud Infrastructure</a> <br>
                             </p>
                         </div>
                     </div>
@@ -228,7 +228,7 @@
                                 <a href="https://hub.docker.com/_/almalinux">{{ i18n "Get Docker Image" }}</a> <br>
                                 <a href="https://quay.io/organization/almalinuxorg">{{ i18n "Get OCI Image from Quay.io" }}</a><br>
                                 <a href="https://github.com/orgs/AlmaLinux/packages">{{ i18n "Get OCI Image from GitHub" }}</a>
-                            </p>    
+                            </p>
                         </div>
                     </div>
                     <div class="col d-flex align-items-stretch">
@@ -237,7 +237,7 @@
                             <h4 class="fw-bold mb-0 pb-2">Live Media</h4>
                             <p>
                                 {{ i18n "AlmaLinux builds Live Media images for GNOME, GNOME Mini, KDE, XFCE and MATE options." }} <br><br>
-                                <a href="https://wiki.almalinux.org/LiveMedia.html">{{ i18n "Get Live Media Image" }}</a> 
+                                <a href="https://wiki.almalinux.org/LiveMedia.html">{{ i18n "Get Live Media Image" }}</a>
                             </p>
                         </div>
                     </div>
@@ -290,7 +290,7 @@
                             </p>
                         </div>
                     </div>
-                </div>    
+                </div>
             </div>
         </div>
 
@@ -503,7 +503,7 @@
                                 <img loading="lazy" src="/brands/MEGWARE.svg" alt="MEGWARE" class="al-backer-logo">
                             </div>
                         </a>
-						
+
                         <a  href="https://www.virtuozzo.com/">
                             <div class="col d-flex flex-fill align-items-center justify-content-center al-backer-logo-container">
                                 <img loading="lazy" src="/brands/virtuozzo.svg" alt="Virtuozzo" class="al-backer-logo">
@@ -557,7 +557,7 @@
 
         <!-- COMMERCIAL SUPPORT -->
         <div class="al-index-commercial-support al-py-lg">
-            <div class="container">
+            <div class="container display-flex">
                 <h2 class="text-center">
                     {{ i18n "Commercial Support" }}
                 </h2>
@@ -565,43 +565,49 @@
 				<!-- to add a row, copy everything from 'start' to 'end' in one of the other rows, and update all of the information appropriately. order-md-last in the class of the image div will display the image right-justified instead of left. -->
 				 <!-- start CyberTrust row -->
                  <div class="row al-commercial-supporter-list">
-                     <div class="col-12 col-md-4 al-commercial-supporter-logo-container d-flex flex-fill justify-content-center">
+                     <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-2 py-md-5">
+				<!-- to add a row, copy everything from 'start' to 'end' in one of the other rows, and update all of the information appropriately. order-md-last in the class of the image div will display the image right-justified instead of left. -->
+				 <!-- start CyberTrust row -->
+                 <div class="row al-commercial-supporter-list col d-flex align-items-start">
+                     <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center">
 					     <a href="https://www.cybertrust.co.jp/almalinux/">
                              <img loading="lazy" src="/brands/cybertrust-japan.svg" alt="CyberTrust Japan" class="al-commercial-supporter-logo">
 						 </a>
                      </div>
 					<div class="col-12 col-md-8">
 					    <p>Cybertrust Japan is a provider of a comprehensive security certification services to various public and private entities globally, and offers comprehensive support for AlmaLinux users. Have also produced MIRACLE LINUX for nearly 20 years.</p>
-					    <a href="https://www.cybertrust.co.jp/almalinux/">Get support</a>
+					    <a class="btn-primary p-2 rounded text-decoration-none"href="https://www.cybertrust.co.jp/almalinux/">Get support</a>
                     </div>
                 </div>
 				<!-- end CyberTrust row -->
 				 <!-- start Tuxcare row -->
-                 <div class="row al-commercial-supporter-list">
-                     <div class="col-12 col-md-4 al-commercial-supporter-logo-container d-flex flex-fill justify-content-center order-md-last">
+                 <div class="row al-commercial-supporter-list col d-flex align-items-start">
+                     <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center">
 					     <a href="https://tuxcare.com/almalinux-enterprise-support/">
                              <img loading="lazy" src="/brands/tuxcare_withtagline.svg" alt="Tuxcare" class="al-commercial-supporter-logo">
 						 </a>
                      </div>
 					<div class="col-12 col-md-8">
 					    <p>For organizations running AlmaLinux, TuxCare’s Enterprise Support provides extended support for up to 16 years, FIPS-compliant security patches, zero-reboot patching, and much more.</p>
-					    <a href="https://tuxcare.com/almalinux-enterprise-support/">Get support</a>
+					    <a class="btn-primary p-2 rounded text-decoration-none" href="https://tuxcare.com/almalinux-enterprise-support/">Get support</a>
                     </div>
                 </div>
 				<!-- end Tuxcare row -->
 				<!-- start OpenLogic row -->
-                <div class="row al-commercial-supporter-list">
-                    <div class="col-12 col-md-4 al-commercial-supporter-logo-container d-flex flex-fill justify-content-center">
+                <div class="row al-commercial-supporter-list col d-flex align-items-start">
+                    <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center rounded">
 					    <a href="https://www.openlogic.com/solutions/enterprise-linux-support/almalinux">
                             <img loading="lazy" src="/brands/logo-openlogic-tagline-white.svg" alt="OpenLogic" class="al-commercial-supporter-logo">
 						</a>
                      </div>
 					 <div class="col-12 col-md-8">
 						<p>Confidently deploy AlmaLinux and all your open source packages with enterprise-grade, 24/7/365 support backed by guaranteed SLAs. Keep your mission-critical apps running smoothly with unlimited tickets and direct access to experienced enterprise architects who put your business first.</p>
-						<a href="https://www.openlogic.com/solutions/enterprise-linux-support/almalinux">Get support</a>
+						<a class="btn-primary p-2 rounded text-decoration-none" href="https://www.openlogic.com/solutions/enterprise-linux-support/almalinux">Get support</a>
                      </div>
                  </div>
-				<!-- end OpenLogic row -->				
+				<!-- end OpenLogic row -->
+                     </div>
+
             </div>
         </div>
 
@@ -655,7 +661,7 @@
                             </div>
                         </div>
                     </div>
-					
+
                     <div class="accordion-item mb-3">
                         <h2 class="accordion-header" id="flush-heading-4">
                             <button class="accordion-button collapsed" type="button" data-toggle="collapse" data-target="#flush-collapse-4" aria-expanded="true" aria-controls="flush-collapse-4">
@@ -718,7 +724,7 @@
                             <div class="accordion-body">
                                 {{ i18n "Since AlmaLinux is binary compatible with RHEL®, your applications and services should be completely interoperable. You can rapidly migrate any number of servers using " }}<a href="https://github.com/AlmaLinux/almalinux-deploy">{{ i18n "AlmaLinux-deploy." }}<a>
 
-                                {{ i18n "If you are using CentOS 7 or 8 and need help upgrading and migrating, check out" }} <a href="{{ "elevate" | relLangURL }}">{{ i18n "ELevate." }}</a> 
+                                {{ i18n "If you are using CentOS 7 or 8 and need help upgrading and migrating, check out" }} <a href="{{ "elevate" | relLangURL }}">{{ i18n "ELevate." }}</a>
                             </div>
                         </div>
                     </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -25,6 +25,10 @@
     .container-measure {
         width: 100%!important;
     }
+
+    .al-commercial-supporter-list {
+        width: 33% !important;
+    }
 }
 @media (min-width: 800px) {
     .display-5 {
@@ -564,14 +568,14 @@
 				<p class="text-center pb-2 mb-5">Minimize your risk while getting the most out of your AlmaLinux systems</p>
 				<!-- to add a row, copy everything from 'start' to 'end' in one of the other rows, and update all of the information appropriately. order-md-last in the class of the image div will display the image right-justified instead of left. -->
 				 <!-- start CyberTrust row -->
-                 <div class="display-flex justify-space-between al-commercial-supporter-list">
+                 <div class="d-flex justify-space-between al-commercial-supporter-list mx-md-width-33" >
                      <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-2 py-md-5 display-flex justify-space-between">
 				<!-- to add a row, copy everything from 'start' to 'end' in one of the other rows, and update all of the information appropriately. order-md-last in the class of the image div will display the image right-justified instead of left. -->
 				 <!-- start CyberTrust row -->
                  <div class="row al-commercial-supporter-list rounded col d-flex align-items-start mx-5">
                      <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center p-2 border-none rounded">
 					     <a href="https://www.cybertrust.co.jp/almalinux/">
-                             <img loading="lazy" src="/brands/cybertrust-japan.svg" alt="CyberTrust Japan" class="al-commercial-supporter-logo">
+                             <img loading="lazy" src="/brands/cybertrust-japan.svg" alt="CyberTrust Japan" class="al-commercial-supporter-logo"  style="max-height: 80px !important;">
 						 </a>
                      </div>
 					<div class="col-12 col-md-8">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -561,15 +561,15 @@
                 <h2 class="text-center">
                     {{ i18n "Commercial Support" }}
                 </h2>
-				<p class="text-center pb-2 mb-5 border-bottom">Minimize your risk while getting the most out of your AlmaLinux systems</p>
+				<p class="text-center pb-2 mb-5">Minimize your risk while getting the most out of your AlmaLinux systems</p>
 				<!-- to add a row, copy everything from 'start' to 'end' in one of the other rows, and update all of the information appropriately. order-md-last in the class of the image div will display the image right-justified instead of left. -->
 				 <!-- start CyberTrust row -->
                  <div class="row al-commercial-supporter-list">
                      <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-4 py-2 py-md-5">
 				<!-- to add a row, copy everything from 'start' to 'end' in one of the other rows, and update all of the information appropriately. order-md-last in the class of the image div will display the image right-justified instead of left. -->
 				 <!-- start CyberTrust row -->
-                 <div class="row al-commercial-supporter-list col d-flex align-items-start">
-                     <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center">
+                 <div class="row al-commercial-supporter-list border rounded col d-flex align-items-start">
+                     <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center p-2 border-none rounded">
 					     <a href="https://www.cybertrust.co.jp/almalinux/">
                              <img loading="lazy" src="/brands/cybertrust-japan.svg" alt="CyberTrust Japan" class="al-commercial-supporter-logo">
 						 </a>
@@ -581,8 +581,8 @@
                 </div>
 				<!-- end CyberTrust row -->
 				 <!-- start Tuxcare row -->
-                 <div class="row al-commercial-supporter-list col d-flex align-items-start">
-                     <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center">
+                 <div class="row al-commercial-supporter-list border rounded col d-flex align-items-start">
+                     <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center p-2 border-none rounded">
 					     <a href="https://tuxcare.com/almalinux-enterprise-support/">
                              <img loading="lazy" src="/brands/tuxcare_withtagline.svg" alt="Tuxcare" class="al-commercial-supporter-logo">
 						 </a>
@@ -594,8 +594,8 @@
                 </div>
 				<!-- end Tuxcare row -->
 				<!-- start OpenLogic row -->
-                <div class="row al-commercial-supporter-list col d-flex align-items-start">
-                    <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center rounded">
+                <div class="row al-commercial-supporter-list col border rounded d-flex align-items-start">
+                    <div class="al-commercial-supporter-logo-container d-flex flex-fill justify-content-center rounded p-2 border-none">
 					    <a href="https://www.openlogic.com/solutions/enterprise-linux-support/almalinux">
                             <img loading="lazy" src="/brands/logo-openlogic-tagline-white.svg" alt="OpenLogic" class="al-commercial-supporter-logo">
 						</a>


### PR DESCRIPTION
Closes #563 

This is a draft because I've run into a few issues with the CSS and HTML for this update. 

- I'm having issues getting the right spacing between the different cards.
- I'm also having issue removing the extra space around the `al-commercial-supporter-logo-container`. 

Any suggestions one way or another would be helpful - from there I can tweak go ahead and tweak the responsiveness. 

Design: 
<img width="1247" alt="Screen Shot 2024-07-10 at 9 34 26 AM" src="https://github.com/AlmaLinux/almalinux.org/assets/59572865/57dab9a2-5086-4133-9536-8ea48d077081">

Current:
<img width="1440" alt="Screen Shot 2024-07-10 at 10 02 19 AM" src="https://github.com/AlmaLinux/almalinux.org/assets/59572865/c464f136-cab9-470b-aeb1-85b7d79214fb">

