### PR TITLE
Updating wording on two blog posts for clarity

### DIFF
--- a/content/blog/2024-07-01-almalinux-9-CVE-2024-6387.md
+++ b/content/blog/2024-07-01-almalinux-9-CVE-2024-6387.md
@@ -22,7 +22,7 @@ Update the openssh package to protect your system against this issue:
 sudo dnf --refresh upgrade openssh
 ```
 
-Confirm the updated version. You are looking for **openssh-8.7p1-38.el9.alma.2**.
+Confirm the updated version has been installed. Our initial patch was included in **openssh-8.7p1-38.el9.alma.2**. After RHEL updated to include the upstream patch, we updated again to ensure we were 100% in line with RHEL. The package you're looking for is listed on the [CVE-2024-6387 errata page](https://errata.almalinux.org/9/ALSA-2024-4312.html)
 
 ```bash
 rpm -q openssh

--- a/content/blog/2024-07-09-cve-2024-6409.md
+++ b/content/blog/2024-07-09-cve-2024-6409.md
@@ -25,7 +25,7 @@ Update the OpenSSH package to protect your system against this issue:
 sudo dnf --refresh upgrade openssh
 ```
 
-Confirm the updated version. You are looking for **openssh-8.7p1-38.el9_4.1.alma.1**.
+Confirm the updated version has been installed. Our initial patch was included in **openssh-8.7p1-38.el9_4.1.alma.1**. After RHEL updated to include the upstream patch, we updated again to ensure we were 100% in line with RHEL. The package you're looking for is listed on the [CVE-2024-6409 errata page](https://errata.almalinux.org/9/ALSA-2024-4457.html)
 
 ```bash
 rpm -q openssh


### PR DESCRIPTION
Got a question about what version of OpenSSH should be installed for an update because our wording wasn't clear. Updated on both of the recent OpenSSH blog posts to be more clear. 