### PR TITLE
Added 404 support

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -13,4 +13,22 @@
     </div>
 </div>
 
+<!-- Matomo | With 404 tracking -->
+<!-- "do not track" settings are honored -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['setDocumentTitle',  '404/URL = ' +  encodeURIComponent(document.location.pathname+document.location.search) + ' /From = ' + encodeURIComponent(document.referrer)]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://matomo.almalinux.org/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '2']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+
 {{end}}


### PR DESCRIPTION
Unlike this issue https://github.com/AlmaLinux/wiki/issues/467 for the wiki, it was much simpler to implement this since the script tag for matomo tracking was present in the footer layout partial and it was not used on the 404 page layout.

![image](https://github.com/user-attachments/assets/e43aa251-7158-43d4-bc2c-695a3681ca1e)

As you can see it was as simple as inserting the tracking script tag and adding this line:

```javascript
_paq.push(['setDocumentTitle',  '404/URL = ' +  encodeURIComponent(document.location.pathname+document.location.search) + ' /From = ' + encodeURIComponent(document.referrer)]);
```

![image](https://github.com/user-attachments/assets/ad0af0bd-26bf-470c-82d7-3c8e48b7b757)

As said in [this guide](https://matomo.org/faq/how-to/faq_60/).

---

Let me know if this works.

Referring to this issue - https://github.com/AlmaLinux/almalinux.org/issues/603.