### PR TITLE
Fixed deprecated warnings

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,9 +3,9 @@ languageCode: en-us
 title: AlmaLinux
 disableKinds:
     - taxonomy
-    - taxonomyTerm
 
-paginate: 15
+pagination:
+  pagerSize: 15
 
 taxonomies:
     author: authors

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -46,8 +46,8 @@
               
                     
                     
-                        {{ if .PrevPage }}
-                        <a class="al-blog-previous-button " href="{{ .PrevPage.RelPermalink }}">
+                        {{ if .Prev }}
+                        <a class="al-blog-previous-button " href="{{ .Prev.RelPermalink }}">
                             <span>« {{ i18n "Previous" }}</span>
 
                         </a> 
@@ -56,8 +56,8 @@
                     
                 
                     
-                        {{ if .NextPage }}
-                        <a class="al-blog-next-button " href="{{ .NextPage.RelPermalink }}">
+                        {{ if .Next }}
+                        <a class="al-blog-next-button " href="{{ .Next.RelPermalink }}">
                             <span> {{ i18n "Next" }} »</span>
                         </a>
                         {{ end }}

--- a/layouts/partials/common/opengraph.html
+++ b/layouts/partials/common/opengraph.html
@@ -15,7 +15,7 @@
         {{- with $.Site.Params.images }}<meta property="og:image" content="{{ index . 0 | absURL }}"/>{{ end -}}
         {{- if not $.Site.Params.images -}}
             <!-- Default image if no other image is found -->
-            <meta property="og:image" content="{{ "images/newhero.png" | absURL }}"/>
+            <meta property="og:image" content="{{ "images/og/newhero.png" | absURL }}"/>
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/layouts/partials/common/opengraph.html
+++ b/layouts/partials/common/opengraph.html
@@ -47,7 +47,6 @@
 {{ end }}{{ end }}
 {{- end }}
 
-{{- /* Deprecate site.Social.facebook_admin in favor of */}}
 {{- $facebookAdmin := "" }}
 {{- with site.Params.social }}
   {{- if reflect.IsMap . }}

--- a/layouts/partials/common/opengraph.html
+++ b/layouts/partials/common/opengraph.html
@@ -15,7 +15,7 @@
         {{- with $.Site.Params.images }}<meta property="og:image" content="{{ index . 0 | absURL }}"/>{{ end -}}
         {{- if not $.Site.Params.images -}}
             <!-- Default image if no other image is found -->
-            <meta property="og:image" content="{{ "images/og/newhero.png" | absURL }}"/>
+            <meta property="og:image" content="{{ "images/newhero.png" | absURL }}"/>
         {{- end -}}
     {{- end -}}
 {{- end -}}
@@ -47,14 +47,14 @@
 {{ end }}{{ end }}
 {{- end }}
 
-{{- /* Deprecate site.Social.facebook_admin in favor of site.Params.social.facebook_admin */}}
+{{- /* Deprecate site.Social.facebook_admin in favor of */}}
 {{- $facebookAdmin := "" }}
 {{- with site.Params.social }}
   {{- if reflect.IsMap . }}
     {{- $facebookAdmin = .facebook_admin }}
   {{- end }}
 {{- else }}
-  {{- with site.Social.facebook_admin }}
+  {{- with site.Params.social.facebook_admin  }}
     {{- $facebookAdmin = . }}
     {{- warnf "The social key in site configuration is deprecated. Use params.social.facebook_admin instead." }}
   {{- end }}


### PR DESCRIPTION
### Changes:

- **File Check Post-Render**: Removed `taxonomyterm` as noted in the [Hugo v0.116.0 release](https://github.com/gohugoio/hugo/releases/tag/v0.116.0).
- **Blog Count Pagination**: Replaced `paginate: 15` with the new `pagination` format:
	```yaml
	pagination:
	  pagerSize: 15
	```
- **Social Links**: Updated to the new syntax in `layouts/partials/common/opengraph.html`.
- **Page Navigation**: Updated `.Page.PrevPage` and `.Page.NextPage` to the new syntax in `layouts/blog/single.html`.

### Posable issues:

I can't explain why, but it seems like the nav menu items look different:

- Old:
    ![image](https://github.com/user-attachments/assets/5ab63e49-d2d1-4e62-b00f-62aca34e3784)
- New:
    ![image](https://github.com/user-attachments/assets/d59fee7f-14a8-496a-a5fb-3f724bcfa346)
    
Also if I try to use the website translated (Locally) I can't access the blog's area, but this seems to be not related to the changes as I tested this on a blank clone.

@codyro If you can generate a test website (from GitHub pages) like I've seen you do sometimes to verify that there is no drastic impact on the website that would be great :grin:. 


> https://github.com/AlmaLinux/almalinux.org/issues/631