### PR TITLE
fix date error

### DIFF
--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -5,7 +5,7 @@ author:
  name: ""
  bio: " "
  image: 
-date: 
+date: '2021-01-01'
 post:
     title: "  "
     image: ""


### PR DESCRIPTION
[Getting an error when](https://github.com/AlmaLinux/almalinux.org/actions/runs/11186588851/job/31105702504) attempting to publish a blog post. I was able to reproduce it locally by upgrading from Hugo 0.134.1 -> 0.135.0. Now when I build the site, I get this error:

`ERROR invalid front matter: date: %!!(MISSING)s(<nil>): see ($webroot)/content/blog/_index.md`

It looks like we're being [hit by this validation](https://github.com/gohugoio/hugo/commit/4c02a52f7c4de651394d01ff4d57d0d380c7b81a) change.  Adding date: '2021-01-01' to that file seems to have solved that error.