### PR TITLE
Fixing icons on the download page

### DIFF
--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -23,6 +23,11 @@
   color: #f1f8ff;
   }
 
+.Photo__Lock, .al-index-dowload-icon{
+  width: 40px;
+  height: 40px;
+}
+
 .al-primary-navbar .container {
   padding-left: 15px !important;
   padding-right: 15px !important;

--- a/layouts/get-almalinux/single.html
+++ b/layouts/get-almalinux/single.html
@@ -184,25 +184,25 @@
               <div class="accordion-body" style="margin-top: 0px; padding: 15px 0 0 0;">
                 <div class="container-all-options mb-3" style="display: flex; justify-content: space-between; padding: 0px 20px;">
                   <a href="#ISO_Images">     
-                    <img loading="lazy" class="al-index-community-icon img" src="/images/iso-icon-F.svg" style="width: 40px; height:40px" alt="ISO Image">
+                    <img loading="lazy" class="al-index-dowload-icon img" src="/images/iso-icon-F.svg" alt="ISO Image">
                   </a>
                   <a href="#Cloud_Images">
-                    <img loading="lazy" class="al-index-community-icon img" src="/images/cloud-icon-F.svg" style="width: 40px; height:40px" alt="Cloud Image">
+                    <img loading="lazy" class="al-index-dowload-icon img" src="/images/cloud-icon-F.svg" alt="Cloud Image">
                   </a>
                   <a href="#Container_Images">
-                    <img loading="lazy" class="al-index-community-icon img" src="/images/container-icon-F.svg" style="width: 40px; height:40px" alt="Container Image">
+                    <img loading="lazy" class="al-index-dowload-icon img" src="/images/container-icon-F.svg" alt="Container Image">
                   </a>
                   <a href="#Live_Media">
-                    <img loading="lazy" class="al-index-community-icon img" src="/images/live-icon-F.svg" style="width: 40px; height:40px" alt="Live Media Image">
+                    <img loading="lazy" class="al-index-dowload-icon img" src="/images/live-icon-F.svg" alt="Live Media Image">
                   </a>
                   <a href="#Vagrant_Boxes">
-                    <img loading="lazy" class="al-index-community-icon img" src="/images/vagrant-icon-F1.svg" style="width: 40px; height:40px" alt="Vagrant Image">
+                    <img loading="lazy" class="al-index-dowload-icon img" src="/images/vagrant-icon-F1.svg" alt="Vagrant Image">
                   </a>
                   <a href="#LXD-LXC">
-                    <img loading="lazy" class="al-index-community-icon img" src="/images/lxd-lcx-icon-F.svg" style="width: 40px; height:40px" alt="LXD-LXC Image">
+                    <img loading="lazy" class="al-index-dowload-icon img" src="/images/lxd-lcx-icon-F.svg" alt="LXD-LXC Image">
                   </a>
                   <a href="#WSL">
-                    <img loading="lazy" class="al-index-community-icon img" src="/images/wsl-icon-F.svg" style="width: 40px; height:40px" alt="WSL Image">
+                    <img loading="lazy" class="al-index-dowload-icon img" src="/images/wsl-icon-F.svg" alt="WSL Image">
                   </a>  
                 </div>
 
@@ -230,7 +230,7 @@
                         <h3>AlmaLinux OS 9</h3>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/9.4/isos/x86_64/AlmaLinux-9.4-x86_64-dvd.iso">AlmaLinux OS 9.4 DVD ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -240,7 +240,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/9.4/isos/x86_64/AlmaLinux-9.4-x86_64-boot.iso">AlmaLinux OS 9.4 Boot ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -250,7 +250,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/9.4/isos/x86_64/AlmaLinux-9.4-x86_64-minimal.iso">AlmaLinux OS 9.4 Minimal ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -268,7 +268,7 @@
                         <h3>AlmaLinux OS 8</h3>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/8.10/isos/x86_64/AlmaLinux-8.10-x86_64-dvd.iso">AlmaLinux OS 8.10 DVD ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -278,7 +278,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/8.10/isos/x86_64/AlmaLinux-8.10-x86_64-boot.iso">AlmaLinux OS 8.10 Boot ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -288,7 +288,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/8.10/isos/x86_64/AlmaLinux-8.10-x86_64-minimal.iso">AlmaLinux OS 8.10 Minimal ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -352,7 +352,7 @@
                       <div class="itemAl_01" style="width: 588px; margin-top: 15px;">
                         <b><a href="https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/AlmaLinux-9-GenericCloud-9.4-20240507.x86_64.qcow2">AlmaLinux OS 9.4</a></b>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -372,7 +372,7 @@
                       <div class="itemAl_02" style="padding-left: 20px; width: 608px; margin-top: 15px;">
                         <b><a href="https://repo.almalinux.org/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.10-20240530.x86_64.qcow2">AlmaLinux OS 8.10</a></b>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px; margin-bottom: 20px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -425,7 +425,7 @@
                       <div class="itemAl_01" style="width: 588px; margin-top: 15px;">
                         <b><a href="https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/AlmaLinux-9-OpenNebula-9.4-20240507.x86_64.qcow2">AlmaLinux OS 9.4</a></b>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -445,7 +445,7 @@
                       <div class="itemAl_02" style="padding-left: 20px; width: 608px; margin-top: 15px;">
                         <b><a href="https://repo.almalinux.org/almalinux/8/cloud/x86_64/images/AlmaLinux-8-OpenNebula-8.10-20240530.x86_64.qcow2">AlmaLinux OS 8.10</a></b>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -840,7 +840,7 @@
                         <h3>AlmaLinux OS 9</h3>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/9.4/isos/aarch64/AlmaLinux-9.4-aarch64-dvd.iso">AlmaLinux OS 9.4 DVD ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -850,7 +850,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/9.4/isos/aarch64/AlmaLinux-9.4-aarch64-boot.iso">AlmaLinux OS 9.4 Boot ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -860,7 +860,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/9.4/isos/aarch64/AlmaLinux-9.4-aarch64-minimal.iso">AlmaLinux OS 9.4 Minimal ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -878,7 +878,7 @@
                         <h3>AlmaLinux OS 8</h3>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/8.10/isos/aarch64/AlmaLinux-8.10-aarch64-dvd.iso">AlmaLinux OS 8.10 DVD ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -888,7 +888,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/8.10/isos/aarch64/AlmaLinux-8.10-aarch64-boot.iso">AlmaLinux OS 8.10 Boot ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -898,7 +898,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/8.10/isos/aarch64/AlmaLinux-8.10-aarch64-minimal.iso">AlmaLinux OS 8.10 Minimal ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -962,7 +962,7 @@
                       <div class="itemAl_01" style="width: 588px; margin-top: 15px;">
                         <b><a href="https://repo.almalinux.org/almalinux/9/cloud/aarch64/images/AlmaLinux-9-GenericCloud-9.4-20240507.aarch64.qcow2">AlmaLinux OS 9.4</a></b>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -982,7 +982,7 @@
                       <div class="itemAl_02" style="padding-left: 20px; width: 608px; margin-top: 15px;">
                         <b><a href="https://repo.almalinux.org/almalinux/8/cloud/aarch64/images/AlmaLinux-8-GenericCloud-8.10-20240530.aarch64.qcow2">AlmaLinux OS 8.10</a></b>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1023,7 +1023,7 @@
                       <div class="itemAl_01" style="width: 588px; margin-top: 15px;">
                         <b><a href="https://repo.almalinux.org/almalinux/9/cloud/aarch64/images/AlmaLinux-9-OpenNebula-9.4-20240507.aarch64.qcow2">AlmaLinux OS 9.4</a></b>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1043,7 +1043,7 @@
                       <div class="itemAl_02" style="padding-left: 20px; width: 608px; margin-top: 15px;">
                         <b><a href="https://repo.almalinux.org/almalinux/8/cloud/aarch64/images/AlmaLinux-8-OpenNebula-8.10-20240530.aarch64.qcow2">AlmaLinux OS 8.10</a></b>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1425,7 +1425,7 @@
                         <h3>AlmaLinux OS 9</h3>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/9.4/isos/s390x/AlmaLinux-9.4-s390x-dvd.iso">AlmaLinux OS 9.4 DVD ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1435,7 +1435,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/9.4/isos/s390x/AlmaLinux-9.4-s390x-boot.iso">AlmaLinux OS 9.4 Boot ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1445,7 +1445,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/9.4/isos/s390x/AlmaLinux-9.4-s390x-minimal.iso">AlmaLinux OS 9.4 Minimal ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1463,7 +1463,7 @@
                         <h3>AlmaLinux OS 8</h3>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/8.10/isos/s390x/AlmaLinux-8.10-s390x-dvd.iso">AlmaLinux OS 8.10 DVD ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1473,7 +1473,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/8.10/isos/s390x/AlmaLinux-8.10-s390x-boot.iso">AlmaLinux OS 8.10 Boot ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1483,7 +1483,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/8.10/isos/s390x/AlmaLinux-8.10-s390x-minimal.iso">AlmaLinux OS 8.10 Minimal ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1517,7 +1517,7 @@
                       <div class="itemAl_01" style="width: 588px; margin-top: 15px;">
                         <b><a href="https://repo.almalinux.org/almalinux/9/cloud/s390x/images/AlmaLinux-9-GenericCloud-9.4-20240507.s390x.qcow2">AlmaLinux OS 9.4</a></b>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1537,7 +1537,7 @@
                       <div class="itemAl_02" style="padding-left: 20px; width: 608px; margin-top: 15px;">
                         <b><a href="https://repo.almalinux.org/almalinux/8/cloud/s390x/images/AlmaLinux-8-GenericCloud-8.10-20240530.s390x.qcow2">AlmaLinux OS 8.10</a></b>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1821,7 +1821,7 @@
                         <h3>AlmaLinux OS 9</h3>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/9.4/isos/ppc64le/AlmaLinux-9.4-ppc64le-dvd.iso">AlmaLinux OS 9.4 DVD ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1831,7 +1831,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/9.4/isos/ppc64le/AlmaLinux-9.4-ppc64le-boot.iso">AlmaLinux OS 9.4 Boot ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1841,7 +1841,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/9.4/isos/ppc64le/AlmaLinux-9.4-ppc64le-minimal.iso">AlmaLinux OS 9.4 Minimal ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1859,7 +1859,7 @@
                         <h3>AlmaLinux OS 8</h3>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/8.10/isos/ppc64le/AlmaLinux-8.10-ppc64le-dvd.iso">AlmaLinux OS 8.10 DVD ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1869,7 +1869,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/8.10/isos/ppc64le/AlmaLinux-8.10-ppc64le-boot.iso">AlmaLinux OS 8.10 Boot ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1879,7 +1879,7 @@
                         </div>
                         <h4 style="margin-bottom: 0px;"><a href="https://repo.almalinux.org/almalinux/8.10/isos/ppc64le/AlmaLinux-8.10-ppc64le-minimal.iso">AlmaLinux OS 8.10 Minimal ISO</a></h4>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1913,7 +1913,7 @@
                       <div class="itemAl_01" style="width: 588px; margin-top: 15px;">
                         <b><a href="https://repo.almalinux.org/almalinux/9/cloud/ppc64le/images/AlmaLinux-9-GenericCloud-9.4-20240507.ppc64le.qcow2">AlmaLinux OS 9.4</a></b>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>
@@ -1933,7 +1933,7 @@
                       <div class="itemAl_02" style="padding-left: 20px; width: 608px; margin-top: 15px;">
                         <b><a href="https://repo.almalinux.org/almalinux/8/cloud/ppc64le/images/AlmaLinux-8-GenericCloud-8.10-20240530.ppc64le.qcow2">AlmaLinux OS 8.10</a></b>
                         <div class="container-locks" style="display: flex; justify-content: flex-start; align-items: center; margin-top: 15px;">
-                          <img class="Photo__Lock" style="width: 40px; height: 40px;" src="/images/alma-fingerprint-A.svg" />
+                          <img class="Photo__Lock" src="/images/alma-fingerprint-A.svg" />
                           <div style="display: flex; flex-direction: column;">
                             <div class="Sha_button" style="display: flex; justify-content: space-between;">
                               <p style="margin-left: 10px; font-family: monospace; font-size: 14px; margin-bottom: 0; margin-top: 0;">SHA-256:</p>


### PR DESCRIPTION
This should fix the current (recently appeared) situation with icons on the download page. Also to try to prevent same issues in the future I renamed their class and moved their width/height to the bundle file 