### PR TITLE
Fixing knownhost and AMD icons

### DIFF
--- a/assets/css/bundle.css
+++ b/assets/css/bundle.css
@@ -174,7 +174,7 @@ border-bottom-color: #14598a !important;
   height: 100%;
 }
 .al-page-index .al-index-backed-by .al-backed-by-list .al-backer-logo {
-  height: 100%;
+  max-height: 100%;
   width: 120px;
 }
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -470,7 +470,7 @@
 
                         <a href="https://www.amd.com/">
                             <div class="col d-flex flex-fill align-items-center justify-content-center al-backer-logo-container">
-                                <img style="height: 70%;" loading="lazy" src="/brands/AMD_Logo.svg" alt="AMD" class="al-backer-logo">
+                                <img loading="lazy" src="/brands/AMD_Logo.svg" alt="AMD" class="al-backer-logo">
                             </div>
                         </a>
 


### PR DESCRIPTION
The AMD and Knownhost logos under 'backers' were getting stretched, causing them to be mis-displayed. These two small changes correct the problems.

Before: 

![2024-11-14_20-47-11](https://github.com/user-attachments/assets/95a574ec-904c-45e2-be39-f023719f6e7d)


After: 
![2024-11-14_20-48-03](https://github.com/user-attachments/assets/0e4d640a-07cb-487e-abab-28840abcf58c)
