### PR TITLE
Updating Live Media for 9.5

### DIFF
--- a/layouts/get-almalinux/single.html
+++ b/layouts/get-almalinux/single.html
@@ -710,7 +710,7 @@
                     </p>
                     <div class="AL" style="display: flex;">
                       <div class="itemAl_01" style="width: 200px;">
-                        <b><a href="https://repo.almalinux.org/almalinux/9/live/x86_64/">AlmaLinux OS 9.4</a></b>
+                        <b><a href="https://repo.almalinux.org/almalinux/9.5/live/x86_64/">AlmaLinux OS 9.5</a></b>
                       </div>
                       <div class="itemAl_02"  style="margin-left: 100px;">
                         <b><a href="https://repo.almalinux.org/almalinux/8/live/x86_64/">AlmaLinux OS 8.10</a></b>
@@ -801,6 +801,9 @@
                   </a>
                   <a href="#Container_Images-2">
                     <img loading="lazy" class="al-index-community-icon img" src="/images/container-icon-F.svg" style="width: 40px; height:40px" alt="Container Image">
+                  </a>
+                  <a href="#Live_Media-2">
+                    <img loading="lazy" class="al-index-dowload-icon img" src="/images/live-icon-F.svg" alt="Live Media Image">
                   </a>
                   <a href="#Raspberry_Pi-2">
                     <img loading="lazy" class="al-index-community-icon img" src="/images/raspberry-pi-icon-F.svg" style="width: 40px; height:40px" alt="Raspberry Image">
@@ -1296,6 +1299,25 @@
                         </div>
                       </div>
                     </div>
+                  </div>
+                </div>
+
+                <div class="container-Live_Media" style="display: flex; flex-direction: column; padding: 40px 20px; background: #0e3b5c;">
+                  <a class="anchor" id="Live_Media-2" style="position: relative; top: -116px;"></a>
+                  <h2 class="pb-2 text-center border-bottom" style="border-bottom-color: #14598a!important;">Live Media</h2>
+                  <div class="al-article-content pb-3 al-wysiwyg" style="padding: 0px!important;">
+                    <p>
+                      {{ i18n "AlmaLinux builds Live Media images for GNOME, GNOME Mini, KDE, XFCE and MATE options." }}<br>
+                      {{ i18n "Supported AlmaLinux OS versions:" }}
+                    </p>
+                    <div class="AL" style="display: flex;">
+                      <div class="itemAl_01" style="width: 200px;">
+                        <b><a href="https://repo.almalinux.org/almalinux/9.5/live/aarch64/">AlmaLinux OS 9.5</a></b>
+                      </div>
+                    </div>
+                    <p style="margin-bottom: 0px;">
+                      {{ i18n "The guide on how to use Live Media images can be found on the " }}<a href="https://wiki.almalinux.org/LiveMedia.html">{{ i18n "AlmaLinux Live Media Wiki Page" }}</a>.
+                    </p>
                   </div>
                 </div>
 


### PR DESCRIPTION
Starting 9.5 release there are also live media images available for aarch64, so I'm adding live media there too 