### PR TITLE
Pin hugo version

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.141.0'
           # extended: true
 
       - name: Generate language files

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.141.0'
           # extended: true
 
       - name: Generate language files


### PR DESCRIPTION
To resolve the last hurdle for #709 - pinning to the version that was used in the [most recent deploy of the website](https://github.com/AlmaLinux/almalinux.org/actions/runs/12876094538/job/35898521829). 

Not entirely sure it's this simple, but if it is then sweet! Just need confirmation from @AlmaLinux/website-infra