### PR TITLE
Adding /migrate redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -16,3 +16,4 @@
 # added for marketing reasons
 /fips/ /blog/2023-09-19-fips-validation-for-almalinux/ 302
 /comparison/ https://wiki.almalinux.org/Comparison.html 302
+/migrate/ https://wiki.almalinux.org/migration/ 307


### PR DESCRIPTION
Using almalinux.org/migrate on some marketing materials, and this will send them to the right place. There's a chance we'll make a website page to match this soon, so I'm marking it as a 307 and setting myself a reminder to re-evaluate in a few months.