### PR TITLE
updating hugo

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.141.0'
+          hugo-version: '0.146.7'
           # extended: true
 
       - name: Generate language files

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.141.0'
+          hugo-version: '0.146.7'
           # extended: true
 
       - name: Generate language files


### PR DESCRIPTION
Updating the hugo version that we're pinned to so I can use some new features. Tested with these URLs to ensure nothing broke in our normal functionality:

http://localhost:1313/blog/
http://localhost:1313/blog/2025-04-08-announcing-96-beta/
http://localhost:1313/blog/2025-02-20-test-patches-for-cve-2025-26465/
http://localhost:1313/almalinux-day-germany-2024/
http://localhost:1313/certification/ecosystem-catalog/
http://localhost:1313/members/