### PR TITLE
fix string in python script

### DIFF
--- a/find_missing_i18n_strings.py
+++ b/find_missing_i18n_strings.py
@@ -20,7 +20,7 @@ for folder, dirs, files in os.walk(rootdir):
             fullpath = os.path.join(folder, file)
             with open(fullpath, 'r', encoding='utf-8') as f:
                 for line in f:
-                    m = re.findall('{{\s+?i18n\s+?(?:"|`)(.*?)(?:"|`)\s+?}}', line, re.DOTALL)
+                    m = re.findall(r'{{\s+?i18n\s+?(?:"|`)(.*?)(?:"|`)\s+?}}', line, re.DOTALL)
                     if m:
                         for string in m:
                             if string not in en:


### PR DESCRIPTION
For issue #814 

I believe it's an issue with seeing '\s' as an escape sequence [1], which using a raw string [2]

[1] https://dnmtechs.com/understanding-and-utilizing-raw-string-regex-in-python-3/
[2] https://realpython.com/python-raw-strings/#in-short-python-raw-strings-ignore-escape-character-sequences

Converting the string to raw allows re to interpret the string as expected.