### PR TITLE
Fix outdated Docker Hub links (closes #744)

### DIFF
--- a/layouts/get-almalinux/single.html
+++ b/layouts/get-almalinux/single.html
@@ -493,7 +493,6 @@
                     </p>
                     <div class="AL" style="display: flex;">
                       <div class="itemAl_01" style="width: 200px;">
-                        <b><a href="https://hub.docker.com/_/almalinux">{{ i18n "Get Docker Image" }}</a></b>
                       </div>
                       <div class="itemAl_02" style="margin-left: 100px;">
                         <b><a href="https://quay.io/organization/almalinuxorg">{{ i18n "Get OCI Image from Quay.io" }}</a></b>
@@ -531,10 +530,8 @@
                           <b>{{ i18n "Link to the repository" }}</b>
                         </div>
                         <div class="itemsOff">
-                          <p><a href="https://hub.docker.com/_/almalinux">hub.docker.com/_/almalinux</a></p>
                         </div>
                         <div class="itemsOff">
-                          <p><a href="https://hub.docker.com/_/almalinux">hub.docker.com/_/almalinux</a></p>
                         </div>
                       </div>
                     </div>
@@ -589,28 +586,24 @@
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-minimal">quay.io/repository/almalinuxorg/9-minimal</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-minimal">hub.docker.com/r/almalinux/9-minimal</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-minimal">github.com/orgs/AlmaLinux/packages/container/package/9-minimal</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-base">quay.io/repository/almalinuxorg/9-base</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-base">hub.docker.com/r/almalinux/9-base</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-base">github.com/orgs/AlmaLinux/packages/container/package/9-base</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-init">quay.io/repository/almalinuxorg/9-init</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-init">hub.docker.com/r/almalinux/9-init</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-init">github.com/orgs/AlmaLinux/packages/container/package/9-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-micro">quay.io/repository/almalinuxorg/9-micro</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-micro">hub.docker.com/r/almalinux/9-micro</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-micro">github.com/orgs/AlmaLinux/packages/container/package/9-micro</a>
                                 </p>
                               </div>
@@ -667,28 +660,24 @@
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-minimal">quay.io/repository/almalinuxorg/8-minimal</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-minimal">hub.docker.com/r/almalinux/8-minimal</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-minimal">github.com/orgs/AlmaLinux/packages/container/package/8-minimal</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-base">quay.io/repository/almalinuxorg/8-base</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-base">hub.docker.com/r/almalinux/8-base</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-base">github.com/orgs/AlmaLinux/packages/container/package/8-base</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-init">quay.io/repository/almalinuxorg/8-init</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-init">hub.docker.com/r/almalinux/8-init</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-init">github.com/orgs/AlmaLinux/packages/container/package/8-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-micro">quay.io/repository/almalinuxorg/8-micro</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-micro">hub.docker.com/r/almalinux/8-micro</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-micro">github.com/orgs/AlmaLinux/packages/container/package/8-micro</a>
                                 </p>
                               </div>
@@ -1095,7 +1084,6 @@
                     </p>
                     <div class="AL" style="display: flex;">
                       <div class="itemAl_01" style="width: 200px;">
-                        <b><a href="https://hub.docker.com/_/almalinux">{{ i18n "Get Docker Image" }}</a></b>
                       </div>
                       <div class="itemAl_02" style="margin-left: 100px;">
                         <b><a href="https://quay.io/organization/almalinuxorg">{{ i18n "Get OCI Image from Quay.io" }}</a></b>
@@ -1133,10 +1121,8 @@
                           <b>{{ i18n "Link to the repository" }}</b>
                         </div>
                         <div class="itemsOff">
-                          <p><a href="https://hub.docker.com/_/almalinux">hub.docker.com/_/almalinux</a></p>
                         </div>
                         <div class="itemsOff">
-                          <p><a href="https://hub.docker.com/_/almalinux">hub.docker.com/_/almalinux</a></p>
                         </div>
                       </div>
                     </div>
@@ -1191,28 +1177,24 @@
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-minimal">quay.io/repository/almalinuxorg/9-minimal</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-minimal">hub.docker.com/r/almalinux/9-minimal</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-minimal">github.com/orgs/AlmaLinux/packages/container/package/9-minimal</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-base">quay.io/repository/almalinuxorg/9-base</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-base">hub.docker.com/r/almalinux/9-base</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-base">github.com/orgs/AlmaLinux/packages/container/package/9-base</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-init">quay.io/repository/almalinuxorg/9-init</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-init">hub.docker.com/r/almalinux/9-init</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-init">github.com/orgs/AlmaLinux/packages/container/package/9-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-micro">quay.io/repository/almalinuxorg/9-micro</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-micro">hub.docker.com/r/almalinux/9-micro</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-micro">github.com/orgs/AlmaLinux/packages/container/package/9-micro</a>
                                 </p>
                               </div>
@@ -1269,28 +1251,24 @@
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-minimal">quay.io/repository/almalinuxorg/8-minimal</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-minimal">hub.docker.com/r/almalinux/8-minimal</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-minimal">github.com/orgs/AlmaLinux/packages/container/package/8-minimal</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-base">quay.io/repository/almalinuxorg/8-base</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-base">hub.docker.com/r/almalinux/8-base</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-base">github.com/orgs/AlmaLinux/packages/container/package/8-base</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-init">quay.io/repository/almalinuxorg/8-init</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-init">hub.docker.com/r/almalinux/8-init</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-init">github.com/orgs/AlmaLinux/packages/container/package/8-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-micro">quay.io/repository/almalinuxorg/8-micro</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-micro">hub.docker.com/r/almalinux/8-micro</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-micro">github.com/orgs/AlmaLinux/packages/container/package/8-micro</a>
                                 </p>
                               </div>
@@ -1593,7 +1571,6 @@
                     </p>
                     <div class="AL" style="display: flex;">
                       <div class="itemAl_01" style="width: 200px;">
-                        <b><a href="https://hub.docker.com/_/almalinux">{{ i18n "Get Docker Image" }}</a></b>
                       </div>
                       <div class="itemAl_02" style="margin-left: 100px;">
                         <b><a href="https://quay.io/organization/almalinuxorg">{{ i18n "Get OCI Image from Quay.io" }}</a></b>
@@ -1631,10 +1608,8 @@
                           <b>{{ i18n "Link to the repository" }}</b>
                         </div>
                         <div class="itemsOff">
-                          <p><a href="https://hub.docker.com/_/almalinux">hub.docker.com/_/almalinux</a></p>
                         </div>
                         <div class="itemsOff">
-                          <p><a href="https://hub.docker.com/_/almalinux">hub.docker.com/_/almalinux</a></p>
                         </div>
                       </div>
                     </div>
@@ -1689,28 +1664,24 @@
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-minimal">quay.io/repository/almalinuxorg/9-minimal</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-minimal">hub.docker.com/r/almalinux/9-minimal</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-minimal">github.com/orgs/AlmaLinux/packages/container/package/9-minimal</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-base">quay.io/repository/almalinuxorg/9-base</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-base">hub.docker.com/r/almalinux/9-base</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-base">github.com/orgs/AlmaLinux/packages/container/package/9-base</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-init">quay.io/repository/almalinuxorg/9-init</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-init">hub.docker.com/r/almalinux/9-init</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-init">github.com/orgs/AlmaLinux/packages/container/package/9-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-micro">quay.io/repository/almalinuxorg/9-micro</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-micro">hub.docker.com/r/almalinux/9-micro</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-micro">github.com/orgs/AlmaLinux/packages/container/package/9-micro</a>
                                 </p>
                               </div>
@@ -1767,28 +1738,24 @@
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-minimal">quay.io/repository/almalinuxorg/8-minimal</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-minimal">hub.docker.com/r/almalinux/8-minimal</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-minimal">github.com/orgs/AlmaLinux/packages/container/package/8-minimal</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-base">quay.io/repository/almalinuxorg/8-base</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-base">hub.docker.com/r/almalinux/8-base</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-base">github.com/orgs/AlmaLinux/packages/container/package/8-base</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-init">quay.io/repository/almalinuxorg/8-init</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-init">hub.docker.com/r/almalinux/8-init</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-init">github.com/orgs/AlmaLinux/packages/container/package/8-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-micro">quay.io/repository/almalinuxorg/8-micro</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-micro">hub.docker.com/r/almalinux/8-micro</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-micro">github.com/orgs/AlmaLinux/packages/container/package/8-micro</a>
                                 </p>
                               </div>
@@ -1989,7 +1956,6 @@
                     </p>
                     <div class="AL" style="display: flex;">
                       <div class="itemAl_01" style="width: 200px;">
-                        <b><a href="https://hub.docker.com/_/almalinux">{{ i18n "Get Docker Image" }}</a></b>
                       </div>
                       <div class="itemAl_02" style="margin-left: 100px;">
                         <b><a href="https://quay.io/organization/almalinuxorg">{{ i18n "Get OCI Image from Quay.io" }}</a></b>
@@ -2027,10 +1993,8 @@
                           <b>{{ i18n "Link to the repository" }}</b>
                         </div>
                         <div class="itemsOff">
-                          <p><a href="https://hub.docker.com/_/almalinux">hub.docker.com/_/almalinux</a></p>
                         </div>
                         <div class="itemsOff">
-                          <p><a href="https://hub.docker.com/_/almalinux">hub.docker.com/_/almalinux</a></p>
                         </div>
                       </div>
                     </div>
@@ -2085,28 +2049,24 @@
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-minimal">quay.io/repository/almalinuxorg/9-minimal</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-minimal">hub.docker.com/r/almalinux/9-minimal</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-minimal">github.com/orgs/AlmaLinux/packages/container/package/9-minimal</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-base">quay.io/repository/almalinuxorg/9-base</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-base">hub.docker.com/r/almalinux/9-base</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-base">github.com/orgs/AlmaLinux/packages/container/package/9-base</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-init">quay.io/repository/almalinuxorg/9-init</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-init">hub.docker.com/r/almalinux/9-init</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-init">github.com/orgs/AlmaLinux/packages/container/package/9-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/9-micro">quay.io/repository/almalinuxorg/9-micro</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/9-micro">hub.docker.com/r/almalinux/9-micro</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/9-micro">github.com/orgs/AlmaLinux/packages/container/package/9-micro</a>
                                 </p>
                               </div>
@@ -2163,28 +2123,24 @@
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-minimal">quay.io/repository/almalinuxorg/8-minimal</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-minimal">hub.docker.com/r/almalinux/8-minimal</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-minimal">github.com/orgs/AlmaLinux/packages/container/package/8-minimal</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-base">quay.io/repository/almalinuxorg/8-base</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-base">hub.docker.com/r/almalinux/8-base</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-base">github.com/orgs/AlmaLinux/packages/container/package/8-base</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-init">quay.io/repository/almalinuxorg/8-init</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-init">hub.docker.com/r/almalinux/8-init</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-init">github.com/orgs/AlmaLinux/packages/container/package/8-init</a>
                                 </p>
                               </div>
                               <div class="itemsTr">
                                 <p>
                                   <a href="https://quay.io/repository/almalinuxorg/8-micro">quay.io/repository/almalinuxorg/8-micro</a><br>
-                                  <a href="https://hub.docker.com/r/almalinux/8-micro">hub.docker.com/r/almalinux/8-micro</a><br>
                                   <a href="https://github.com/orgs/AlmaLinux/packages/container/package/8-micro">github.com/orgs/AlmaLinux/packages/container/package/8-micro</a>
                                 </p>
                               </div>
@@ -2216,3 +2172,8 @@ document.querySelector('[class="tab-button"]').classList.add('active');
 </script>
 
 {{ end }}
+<b><a href="https://hub.docker.com/_/almalinux">{{ i18n "Get AlmaLinux Official Image on Docker Hub" }}</a></b>
+<p>
+  Find all AlmaLinux 8 & 9 images, including minimal, base, init, and micro variants, directly on Docker Hub.
+  <a href="https://hub.docker.com/_/almalinux">Visit Docker Hub →</a>
+</p>


### PR DESCRIPTION
This PR fixes issue #744 by updating/removing outdated Docker Hub links.