### PR TITLE
9.6 updates blog not generating

### DIFF
--- a/content/blog/2025-06-05-almalinux-96-images-updates.md
+++ b/content/blog/2025-06-05-almalinux-96-images-updates.md
@@ -5,7 +5,7 @@ author:
  name: "Yuriy Kohut"
  bio: "Release Automation Engineer"
  image: /users/yuriy-kohut.jpg
-date: 2025-06-05
+date: '2025-06-05'
 images:
   - /blog-images/2025/2025-06-03-96-images-updates.png
 post: 


### PR DESCRIPTION
It seems the blog https://github.com/AlmaLinux/almalinux.org/pull/840 isn't generating, probably due to this typo