### PR TITLE
Raspberry Pi download update

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -855,5 +855,6 @@
    "Join us August 9th for ": "Join us August 9th for ",
    "to AlmaLinux 9.6": "to AlmaLinux 9.6",
    "Say Hello": "Say Hello",
-   "to AlmaLinux 10.0!": "to AlmaLinux 10.0!"
+   "to AlmaLinux 10.0!": "to AlmaLinux 10.0!",
+   "Default Login": "Default Login"
 }

--- a/layouts/get-almalinux/single.html
+++ b/layouts/get-almalinux/single.html
@@ -1410,13 +1410,17 @@
                     </p>
                     <div class="AL" style="display: flex;">
                       <div class="itemAl_01" style="width: 200px;">
-                        <b><a href="https://repo.almalinux.org/rpi/9/images/">AlmaLinux OS 9.5</a></b>
+                        <b><a href="https://repo.almalinux.org/almalinux/10/raspberrypi/images/">AlmaLinux OS 10.0</a></b>
                       </div>
-                      <div class="itemAl_02"  style="margin-left: 100px;">
-                        <b><a href="https://repo.almalinux.org/rpi/images/">AlmaLinux OS 8.10</a></b>
+                      <div class="itemAl_02" style="width: 200px;">
+                        <b><a href="https://repo.almalinux.org/almalinux/9/raspberrypi/images/">AlmaLinux OS 9.6</a></b>
+                      </div>
+                      <div class="itemAl_03"  style="margin-left: 100px;">
+                        <b><a href="https://repo.almalinux.org/almalinux/8/raspberrypi/images/">AlmaLinux OS 8.10</a></b>
                       </div>
                     </div>
                     <p style="margin-bottom: 0px;">
+                      {{ i18n "Default Login" }}: almalinux / almalinux (username/password) <br>
                       {{ i18n "More details can be found on the" }} 
                       <a href="https://wiki.almalinux.org/documentation/raspberry-pi.html"> {{ i18n "AlmaLinux Raspberry Pi Wiki Page" }}</a>
                     </p>


### PR DESCRIPTION
Update links and text for Raspberry Pi images. I also included the default username/password for the image as it allows users to get hands on sooner, saving time scrolling through the wiki page to find it.

![image](https://github.com/user-attachments/assets/d94e19d5-40f3-46f8-8e7c-341b859a25b1)
