### PR TITLE
Correct silver sponsor fee (plus whitespace fixes)

### DIFF
--- a/layouts/members/single.html
+++ b/layouts/members/single.html
@@ -79,7 +79,7 @@
 </style>
 <!-- HERO -->
 <section id="hc-hero">
-  <div class="container px-0 al-py-lg">  
+  <div class="container px-0 al-py-lg">
     <div class="row">
       <div class="col-lg">
         <h1 class="display-5 fw-bold">AlmaLinux OS Foundation {{ i18n "Membership" }}</h1>
@@ -107,7 +107,7 @@
             </p>
 	        <div class="pt-1">
 	            <a href="https://docs.google.com/forms/d/e/1FAIpQLScJx_mgkkWgBLr-jF1X6VBizXxQxboy1l5jVS-5eP6d2n5ThA/viewform" class="btn btn-primary al-member-apply-cta" target="_blank">
-					<i class="bi bi-people-fill"></i> 
+					<i class="bi bi-people-fill"></i>
 	                {{ i18n "Apply" }}
 	            </a>
 	        </div>
@@ -121,7 +121,7 @@
             </p>
 	        <div class="pt-1">
 	            <a href="https://docs.google.com/forms/d/e/1FAIpQLSdulxH8cv5fzqkIyLanxzvxoBTnrz8Y0JPbseXjzPXRsPT_kQ/viewform" class="btn btn-primary al-member-apply-cta" target="_blank">
-					<i class="bi bi-people-fill"></i> 
+					<i class="bi bi-people-fill"></i>
 	                {{ i18n "Apply" }}
 	            </a>
 	        </div>
@@ -134,7 +134,7 @@
 	        </p>
 	        <div class="pt-1">
             	<a href="https://docs.google.com/forms/d/e/1FAIpQLSddSD32Feb2KUvPTktZNpY_LInyDBRpXxt6XEIjiYIHmP3t7Q/viewform" class="btn btn-primary al-member-apply-cta" target="_blank">
-					<i class="bi bi-people-fill"></i> 
+					<i class="bi bi-people-fill"></i>
 	                {{ i18n "Apply" }}
 	            </a>
 	        </div>
@@ -147,7 +147,7 @@
 	        {{ i18n "Do you have membership related questions?" }}
 	        <a href="mailto:membership@almalinux.org">{{ i18n "Email the membership committee" }}</a>.
 	    </div>
-	</div>   
+	</div>
 <!-- Acts as an anchor for links -->
 	<div id="apply"></div>
 
@@ -155,7 +155,7 @@
 	<h3>{{ i18n "Join the" }} AlmaLinux OS Foundation</h6>
 		<p>{{ i18n "The AlmaLinux OS Foundation's membership structure is intentionally permissive, because it is important for us that anyone who has a stake in the future of AlmaLinux is allowed to have a voice in the future of AlmaLinux. Whether you join as a sponsor member or an individual contributor or a mirror host, your support of AlmaLinux and your opinion deserves to be heard." }}</p>
 		<p>{{ i18n "Membership of the foundation is determined and managed by the Membership Committee. The membership committee meets regularly to review applications and welcome new members to the foundation. The qualifications for each type of membership are below. If you have any intersest in joining the membership committee, reach out to the committee directly via email" }}! <a href="mailto:membership@almalinux.org">{{ i18n "Email the membership committee" }}</a></p>
-  
+
 	<h2>{{ i18n "Free member qualifications and benefits" }}</h2>
 		<p>{{ i18n "All of the information below is pulled directly from where it was defined in the" }} <a href="https://almalinux.org/p/foundation-bylaws/">{{ i18n "AlmaLinux OS Foundation ByLaws" }}</a>, {{ i18n "and the expanded membership document adopted by the board of directors in" }} <a href="https://docs.google.com/document/d/1TGYu9Ga8oqIN16RxUQzqbFJZTImy5EQDO1tOhq4ymGw/edit?tab=t.0#heading=h.wpc7akebv4b">{{ i18n "April of 2024" }}</a>.</p>
 	<div class="row pb-2">
@@ -177,7 +177,7 @@
 	        </ul>
 		  <div class="pt-1">
 		        <a href="https://docs.google.com/forms/d/e/1FAIpQLScJx_mgkkWgBLr-jF1X6VBizXxQxboy1l5jVS-5eP6d2n5ThA/viewform" class="btn btn-primary al-member-apply-cta" target="_blank">
-					<i class="bi bi-people-fill"></i> 
+					<i class="bi bi-people-fill"></i>
 		            {{ i18n "Apply" }}
 		        </a>
 		  </div>
@@ -200,13 +200,13 @@
 	        </ul>
 	    <div class="pt-1">
 	        <a href="https://docs.google.com/forms/d/e/1FAIpQLSdulxH8cv5fzqkIyLanxzvxoBTnrz8Y0JPbseXjzPXRsPT_kQ/viewform" class="btn btn-primary al-member-apply-cta" target="_blank">
-				<i class="bi bi-people-fill"></i> 
+				<i class="bi bi-people-fill"></i>
 	            {{ i18n "Apply" }}
 	        </a>
 	    </div>
 	  </div> <!-- end mirror column-->
-	<!-- end contributor/mirror row --></div>	
-  
+	<!-- end contributor/mirror row --></div>
+
 	<!-- start sponsor member content -->
 	<div>
 		<h2 class="pb-3"><u>{{ i18n "Sponsor member qualifications and benefits" }}</u></h2>
@@ -226,7 +226,7 @@
 	<div class="row"><!-- second of Platinum rows -->
 		<div class="col-lg">
 			<p>{{ i18n "Platinum membership is a our highest tier and is tailor-made for companies who understand the importance of heavily sponsoring open source projects that the world relies on, and who want to ensure that the AlmaLinux project is able to continue to deliver on its promise of long-term stability." }}</p>
-			<h4 class="pb-1">{{ i18n "Current platinum sponsor members" }}</h4>	
+			<h4 class="pb-1">{{ i18n "Current platinum sponsor members" }}</h4>
 				<div class="row align-items-center justify-content-center">
 		            <div class="col-sm" style="max-width: 180px;">
 						<a href="https://www.cloudlinux.com">
@@ -278,17 +278,17 @@
 				</ul>
 	        <div class="pt-1">
 	            <a href="https://docs.google.com/forms/d/e/1FAIpQLSddSD32Feb2KUvPTktZNpY_LInyDBRpXxt6XEIjiYIHmP3t7Q/viewform" class="btn btn-primary al-member-apply-cta" target="_blank">
-					<i class="bi bi-people-fill"></i> 
+					<i class="bi bi-people-fill"></i>
 	                {{ i18n "Apply" }}
 	            </a>
 	        </div>
-	    </div> 
+	    </div>
 	</div><!-- end Platinum rows -->
-		
+
 	<div class="row"><!-- Start other paid Sponsor Memberships -->
 		<div class="col-sm"><!-- start silver column -->
 			<h3 class="pb-3">{{ i18n "Silver Sponsor Member" }}
-			
+
 				<img loading="lazy" src="/membership-images/silver_sponsor_member.png" alt="Silver Sponsor Member" class="rounded align-items-center py-2" style="width:35%;"></h3> <!-- membership image created in Canva - ask marketing SIG for more information -->
 				<p>Silver Sponsor Members tend to be startups or companies who are compelled to show their support for AlmaLinux, but don't find that a larger investment meets their needs.</p>
 			<h4>{{ i18n "Benefits" }}</h4>
@@ -298,7 +298,7 @@
 	                <li>{{ i18n "Opportunity to nominate someone for election to the board of directors" }}</li>
 	                <li>5 {{ i18n "votes for each open board seat" }}</li>
 	            </ul>
-			
+
 	        <h5>{{ i18n "Marketing Benefits" }}</h5>
 	            <ul>
 	                <li>{{ i18n "Company logo on AlmaLinux website in one section/category" }}</li>
@@ -309,18 +309,18 @@
 			<h4>{{ i18n "Membership Fee" }}</h4>
 				<ul>
 					<li>$2,500 OR</li>
-					<li>{{ i18n "Three dedicated full-time employees working on AlmaLinux" }}</li>
+					<li>{{ i18n "An equivalent contribution of hardware or services" }}</li>
 				</ul>
 	        <div class="pt-1">
 	            <a href="https://docs.google.com/forms/d/e/1FAIpQLSddSD32Feb2KUvPTktZNpY_LInyDBRpXxt6XEIjiYIHmP3t7Q/viewform" class="btn btn-primary al-member-apply-cta" target="_blank">
-					<i class="bi bi-people-fill"></i> 
+					<i class="bi bi-people-fill"></i>
 	                {{ i18n "Apply" }}
 	            </a>
 	        </div>
 		</div> <!-- end silver column -->
 		<div class="col-sm"><!-- start Ruby column -->
 			<h3 class="pb-3">{{ i18n "Ruby Sponsor Member" }}
-			
+
 				<img loading="lazy" src="/membership-images/ruby_sponsor_member.png" alt="Silver Sponsor Member" class="rounded align-items-center py-2" style="width:35%;"></h3> <!-- membership image created in Canva - ask marketing SIG for more information -->
 				<p>{{ i18n "Ruby Sponsor Members are primarily companies that want to be able to" }} <a href="https://almalinux.org/blog/2024-04-11-secure-boot-with-almalinux/">{{ i18n "support AlmaLinux users' use of secure boot" }}</a>.</p>
 			<h4>{{ i18n "Benefits" }}</h4>
@@ -347,14 +347,14 @@
 				</ul>
 	        <div class="pt-1">
 	            <a href="https://docs.google.com/forms/d/e/1FAIpQLSddSD32Feb2KUvPTktZNpY_LInyDBRpXxt6XEIjiYIHmP3t7Q/viewform" class="btn btn-primary al-member-apply-cta" target="_blank">
-					<i class="bi bi-people-fill"></i> 
+					<i class="bi bi-people-fill"></i>
 	                {{ i18n "Apply" }}
 	            </a>
 	        </div>
 		</div> <!-- end Ruby column -->
 		<div class="col-sm"> <!-- start gold column -->
 			<h3 class="pb-3">{{ i18n "Gold Sponsor Member" }}
-			
+
 				<img loading="lazy" src="/membership-images/gold_sponsor_member.png" alt="Gold Sponsor Member" class="rounded align-items-center py-2" style="width:35%;"></h3> <!-- membership image created in Canva - ask marketing SIG for more information -->
 				<p>{{ i18n "Gold Sponsor Members are established companies who believe in the importance of open source and free operating systems, and see the value in AlmaLinux continuing to serve its users." }}</p>
 			<h4>{{ i18n "Benefits" }}</h4>
@@ -372,7 +372,7 @@
 	                <li> {{ i18n "1 sponsor webinar per year" }}</li>
 	                <li> {{ i18n "Up to four sponsored blog posts per year to be posted on the AlmaLinux blog" }}</li>
 	                <li> {{ i18n "AlmaLinux will assist in promoting your appropriate social media for Linux-related content (e.g. tweets and retweets)" }}</li>
-	                <li>{{ i18n "Inclusion in a round-up blog post of new Gold members" }}</li>				
+	                <li>{{ i18n "Inclusion in a round-up blog post of new Gold members" }}</li>
 	                <li>{{ i18n "Your company's events featured on our" }} <a href="https://events.almalinux.org">{{ i18n "community events calendar" }}</a></li>
 	                <li>{{ i18n "AlmaLinux member logo for your site" }}</li>
 	            </ul>
@@ -386,7 +386,7 @@
 				</ul>
 	        <div class="pt-1">
 	            <a href="https://docs.google.com/forms/d/e/1FAIpQLSddSD32Feb2KUvPTktZNpY_LInyDBRpXxt6XEIjiYIHmP3t7Q" class="btn btn-primary al-member-apply-cta" target="_blank">
-					<i class="bi bi-people-fill"></i> 
+					<i class="bi bi-people-fill"></i>
 	                {{ i18n "Apply" }}
 	            </a>
 	        </div>
@@ -394,13 +394,13 @@
 	</div><!-- end other paid Sponsor Memberships -->
 
 <!-- end sponsor member descriptions -->
-        
+
     <div class="al-members">
 	    <h2 class="mb-5"> {{ i18n "Board of Directors" }} </h2>
 		<p> {{ i18n "The AlmaLinux OS Foundation is lead by a community elected board of directors who hold regular meetings. Agendas and minutes for those meetings are shared with the public on" }} <a href="https://wiki.almalinux.org/Transparency.html#minutes-of-almalinux-os-foundation-board-meetings">{{ i18n "the AlmaLinux Wiki" }}</a>. {{ i18n "The board, once elected, chooses its offices, including the chair of the board. Elections are held as regularly as needed to fill vacancies. The wiki also houses historical details about the" }} <a href="https://wiki.almalinux.org/Transparency.html#first-board-elections">{{ i18n "election candidates and processes" }}</a>.
 		</p>
         <div class="row">
-<!-- benny -->						
+<!-- benny -->
                 <div class="col-xl-3 col-sm-6 mb-5">
                     <div class="py-5 px-4 text-center al-member-item">
                         <div>
@@ -411,8 +411,8 @@
                         <div class="small fw-light">AlmaLinux OS Foundation</div>
                     </div>
                 </div>
-<!-- end benny -->						
-<!-- Jack -->						
+<!-- end benny -->
+<!-- Jack -->
                 <div class="col-xl-3 col-sm-6 mb-5">
                     <div class="py-5 px-4 text-center al-member-item">
                         <div>
@@ -423,8 +423,8 @@
                         <div class="small fw-light">Microsoft Azure AOSI</div>
                     </div>
                 </div>
-<!-- end Jack -->						
-<!-- Jesse -->						
+<!-- end Jack -->
+<!-- Jesse -->
                 <div class="col-xl-3 col-sm-6 mb-5">
                     <div class="py-5 px-4 text-center al-member-item">
                         <div>
@@ -435,8 +435,8 @@
                         <div class="small fw-light">WebPros</div>
                     </div>
                 </div>
-<!-- end Jesse -->						
-<!-- Simon -->						
+<!-- end Jesse -->
+<!-- Simon -->
                 <div class="col-xl-3 col-sm-6 mb-5">
                     <div class="py-5 px-4 text-center al-member-item">
                         <div>
@@ -447,8 +447,8 @@
                         <div class="small fw-light"></div>
                     </div>
                 </div>
-<!-- end Simon -->						
-<!-- Moshe -->						
+<!-- end Simon -->
+<!-- Moshe -->
              <div class="col-xl-3 col-sm-6 mb-5">
                 <div class="py-5 px-4 text-center al-member-item">
                     <div>
@@ -459,8 +459,8 @@
                         <div class="small fw-light">Codenotary Inc.</div>
                 </div>
              </div>
-<!-- end Moshe -->						
-<!-- Daniel -->						
+<!-- end Moshe -->
+<!-- Daniel -->
              <div class="col-xl-3 col-sm-6 mb-5">
                 <div class="py-5 px-4 text-center al-member-item">
                     <div>
@@ -471,8 +471,8 @@
                         <div class="small fw-light">KnownHost</div>
                 </div>
              </div>
-<!-- end Daniel -->		
-<!-- Jun -->						
+<!-- end Daniel -->
+<!-- Jun -->
              <div class="col-xl-3 col-sm-6 mb-5">
                 <div class="py-5 px-4 text-center al-member-item">
                     <div>
@@ -483,8 +483,8 @@
                         <div class="small fw-light">Cybertrust Japan</div>
                 </div>
              </div>
-<!-- end Jun -->		
-<!-- Alex -->						
+<!-- end Jun -->
+<!-- Alex -->
              <div class="col-xl-3 col-sm-6 mb-5">
                 <div class="py-5 px-4 text-center al-member-item">
                     <div>
@@ -495,8 +495,8 @@
                         <div class="small fw-light">CERN</div>
                 </div>
              </div>
-<!-- end Alex -->		
-<!-- David -->						
+<!-- end Alex -->
+<!-- David -->
              <div class="col-xl-3 col-sm-6 mb-5">
                 <div class="py-5 px-4 text-center al-member-item">
                     <div>
@@ -508,7 +508,7 @@
                         <div class="small fw-light">Non-voting Invited Expert</div>
                 </div>
              </div>
-<!-- end David -->	                    
+<!-- end David -->
         </div>
     </div>
 </div><!-- end container div -->


### PR DESCRIPTION
The membership fee for Silver sponsors was copy-pasted from the Platinum sponsors entry, this fixes it according to the official [AlmaLinux OS Foundation Membership levels and Benefits](https://docs.google.com/document/d/1TGYu9Ga8oqIN16RxUQzqbFJZTImy5EQDO1tOhq4ymGw/edit?tab=t.0) document.