### PR TITLE
updating references to the now-retired FTI brand image.

### DIFF
--- a/layouts/aldt-2024/single.html
+++ b/layouts/aldt-2024/single.html
@@ -884,7 +884,7 @@ end thank you block-->
                   class="col d-flex flex-fill align-items-center justify-content-center al-backer-logo-container">
                   <img
                     loading="lazy"
-                    src="/brands/fti_brand.svg"
+                    src="/brands/retired/fti_brand.svg"
                     alt="Fsas Technologies Inc."
                     class="al-backer-logo-small" />
                 </div>

--- a/layouts/almalinux-day-vancouver-2025/single.html
+++ b/layouts/almalinux-day-vancouver-2025/single.html
@@ -697,7 +697,7 @@
                     class="col d-flex flex-fill align-items-center justify-content-center al-backer-logo-container">
                     <img
                       loading="lazy"
-                      src="/brands/fti_brand.svg"
+                      src="/brands/retired/fti_brand.svg"
                       alt="Fsas Technologies Inc."
                       class="al-backer-logo-small" />
                   </div>


### PR DESCRIPTION
PR #921 included a move of an old logo. This updates references to that logo on old event pages. 