### PR TITLE
Remove reviewer 'alexiri' from workflow

### DIFF
--- a/.github/workflows/update-checksums.yaml
+++ b/.github/workflows/update-checksums.yaml
@@ -42,4 +42,3 @@ jobs:
           labels: automated, checksums
           delete-branch: true
           assignees: bennyvasquez, jonathanspw, andrewlukoshko
-          reviewers: alexiri


### PR DESCRIPTION
Turns out I can't be a reviewer because I'm not a collaborator in this repo, though weirdly the action actually does the right thing...