### PR TITLE
Migrate Cloudflare Pages deploy workflows to Wrangler and post preview URL on PRs

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
+      pull-requests: write
     name: Publish Preview to Cloudflare Pages
     steps:
       - uses: actions/checkout@v4
@@ -49,9 +50,30 @@ jobs:
         run: npx pagefind --site "public"
 
       - name: Publish to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
-          directory: public
+          command: pages deploy public --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }} --branch=${{ github.head_ref }}
+
+      - name: Comment deployment URL on PR
+        if: always() && github.event.pull_request.number
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const aliasUrl = `${{ steps.deploy.outputs.pages-deployment-alias-url }}`;
+            const deploymentUrl = `${{ steps.deploy.outputs.deployment-url }}`;
+            const url = aliasUrl || deploymentUrl;
+            const status = `${{ steps.deploy.outcome }}`;
+
+            const body = status === "success" && url
+              ? `✅ Preview deployment is ready: ${url}`
+              : `⚠️ Preview deployment step finished with status: ${status}.`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,9 +64,8 @@ jobs:
         run: npx pagefind --site "public"
 
       - name: Publish to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
-          directory: public
+          command: pages deploy public --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }}


### PR DESCRIPTION
⚠️ Note that I haven't actually tested this, I don't have the required secrets so I can't run it in my fork. The test deploy should be enough to see if it works, though.

`cloudflare/pages-action` is deprecated, and preview deployments did not report the resulting URL back to pull requests. This updates the Cloudflare deploy workflows to `cloudflare/wrangler-action` and adds PR-facing deployment feedback for previews.

- **Workflow migration: deprecated Pages action → Wrangler**
  - Replaced `cloudflare/pages-action@v1` with `cloudflare/wrangler-action@v3` in:
    - `.github/workflows/publish.yml`
    - `.github/workflows/publish-preview.yml`
  - Switched to explicit Wrangler Pages deploy commands:
    - production: `pages deploy public --project-name=<project>`
    - preview: `pages deploy public --project-name=<project> --branch=<pr-branch>`

- **Preview deployment reporting in PRs**
  - Added a post-deploy comment step in `publish-preview.yml` using `actions/github-script`.
  - The comment reports completion and includes the deployed URL when available.
  - URL resolution prefers preview alias output, then falls back to deployment URL output.

- **Permissions adjustment for PR commenting**
  - Added `pull-requests: write` to preview workflow job permissions to allow posting comments.
