### PR TITLE
CVE-2026-31431: announce patched kernels in production repos

### DIFF
--- a/content/blog/2026-05-01-cve-2026-31431-copy-fail.md
+++ b/content/blog/2026-05-01-cve-2026-31431-copy-fail.md
@@ -1,5 +1,5 @@
 ---
-title: "Copy Fail (CVE-2026-31431) patch ready for testing"
+title: "Copy Fail (CVE-2026-31431) Patches Released"
 type: blog
 author:
   name: "Jonathan Wright"
@@ -13,7 +13,28 @@ post:
   image: /blog-images/2026/2026-05-01-copy-fail-cve-2026-31431.png
 ---
 
-## The Announcement
+## Update: Patched kernels are now in production
+
+**2026-05-01 21:07 UTC** — The patched kernels are now rolling out to **production** repositories/mirrors. You no longer need to enable the testing repo to get them. Just run:
+
+```bash
+sudo dnf clean metadata && sudo dnf upgrade
+sudo reboot
+```
+
+Most mirrors have a sync frequency of 3 hours. If the updates are not available to you yet we recommend trying again in about an hour.
+
+The testing-repo instructions further down in this post remain for reference but are no longer the recommended path.
+
+The kernels released to production repositories are bit for bit identical to those from testing. We'd like to thank everyone who helped with testing - it was the best involvement we've had for a community call for testing to date and contributed to the speed of getting these patches into production repositories!
+
+Errata is available for all three supported AlmaLinux versions:
+
+- 8: https://errata.almalinux.org/8/ALSA-2026-A001.html
+- 9: https://errata.almalinux.org/9/ALSA-2026-A002.html
+- 10: https://errata.almalinux.org/10/ALSA-2026-A003.html
+
+---
 
 On April 29, the team at [Xint Code disclosed](https://copy.fail/) a Linux kernel flaw they have named _Copy Fail_, tracked as [CVE-2026-31431](https://nvd.nist.gov/vuln/detail/CVE-2026-31431). The bug lives in the kernel's crypto subsystem — a logic flaw in `authencesn` chained through `AF_ALG` and `splice()` — and it lets any unprivileged local user escalate to root with a 732-byte exploit that the researchers report works unmodified across every mainstream distribution built since 2017. Every supported AlmaLinux release is affected.
 
@@ -100,5 +121,7 @@ Thanks to **Andrew Lukoshko** of the AlmaLinux core team for turning around patc
 Remaining aware of these vulnerabilities and acting quickly can keep your system and data safe. Follow the AlmaLinux Blog, join the [Mattermost Community Chat](https://chat.almalinux.org/), and subscribe to [Announce](https://lists.almalinux.org/mailman3/lists/announce.lists.almalinux.org/) and [Security Mailing List](https://lists.almalinux.org/mailman3/lists/security.lists.almalinux.org/) to stay informed and updated. We will update this post when the patched kernels move from testing to production.
 
 ## Changelog
+
+- **2026-05-01 21:07 UTC** — Patched kernels released to the AlmaLinux production repositories. Added a notice at the top of the post directing readers to `sudo dnf clean all && sudo dnf upgrade` instead of the testing-repo flow described below. Post title updated to reflect release.
 
 - **2026-05-01 16:30 UTC** — Updated the kernel update command from `dnf update kernel` to `dnf update 'kernel*' --enablerepo=almalinux-testing` so that all kernel-related packages (e.g. `kernel-core`, `kernel-modules`, `kernel-headers`) are updated together and if the `almalinux-testing` repo is already present but disabled, this will enable it for the transaction. This resolves an issue, unrelated to this patch, where `kernel-modules-extra` is not upgraded when only upgrading `kernel` and an issue with `almalinux-testing` being present but disabled so the instructions didn't grab the updates. Also added `sudo` to the `dnf` commands for consistency with the `reboot` step.

--- a/layouts/partials/common/nav.html
+++ b/layouts/partials/common/nav.html
@@ -281,7 +281,7 @@
       <a href="{{ "/blog/2026-05-01-cve-2026-31431-copy-fail/" | relLangURL }}"
         >Copy Fail (CVE-2026-31431)</a
       >
-      patched kernels are in testing!
+      patched kernels released!
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adds a production-release notice at the top of the Copy Fail post, pointing readers to `sudo dnf clean all && sudo dnf upgrade` and flagging the testing-repo flow below as no longer the recommended path. Adds a matching changelog entry.