### PR TITLE
Dirty Frag: site banner + sudo on mitigation command

### DIFF
--- a/content/blog/2026-05-07-dirty-frag.md
+++ b/content/blog/2026-05-07-dirty-frag.md
@@ -96,7 +96,7 @@ Confirm with `uname -r` against the Kitten version listed below.
 If updating and rebooting right now is not an option, you can neutralize the attack surface by blacklisting the affected modules. None of `esp4`, `esp6`, or `rxrpc` are loaded on a typical workload that does not use IPsec transport mode or AFS, so on most systems this is safe to apply immediately:
 
 ```bash
-sh -c "printf 'install esp4 /bin/false\ninstall esp6 /bin/false\ninstall rxrpc /bin/false\n' > /etc/modprobe.d/dirtyfrag.conf; rmmod esp4 esp6 rxrpc 2>/dev/null; true"
+sudo sh -c "printf 'install esp4 /bin/false\ninstall esp6 /bin/false\ninstall rxrpc /bin/false\n' > /etc/modprobe.d/dirtyfrag.conf; rmmod esp4 esp6 rxrpc 2>/dev/null; true"
 ```
 
 This writes a `modprobe` config that prevents the three modules from loading, and unloads them if they happen to be loaded already (the `rmmod` is best-effort and silent if the module isn't present). The command is safe to run unchanged on all supported releases. To revert, remove `/etc/modprobe.d/dirtyfrag.conf`.

--- a/layouts/partials/common/nav.html
+++ b/layouts/partials/common/nav.html
@@ -281,7 +281,10 @@
       <a href="{{ "/blog/2026-05-01-cve-2026-31431-copy-fail/" | relLangURL }}"
         >Copy Fail (CVE-2026-31431)</a
       >
-      patched kernels released!
+      patched kernels released! &nbsp;|&nbsp;
+      <i class="bi bi-shield-exclamation"></i>
+      <a href="{{ "/blog/2026-05-07-dirty-frag/" | relLangURL }}">Dirty Frag</a>
+      patched kernels are in testing!
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adds a Dirty Frag segment to the top-of-site MOTD banner alongside the existing Copy Fail notice, pointing at the testing-stage blog post. Prefixes the modprobe-blacklist mitigation snippet in the post with sudo so it lines up with the other commands and works for non-root users.