### PR TITLE
Dirty Frag: cite CVE-2026-43284

### DIFF
--- a/content/blog/2026-05-07-dirty-frag.md
+++ b/content/blog/2026-05-07-dirty-frag.md
@@ -1,5 +1,5 @@
 ---
-title: "Dirty Frag vulnerability fix is ready for testing"
+title: "Dirty Frag (CVE-2026-43284) vulnerability fix is ready for testing"
 type: blog
 author:
   name: "Andrew Lukoshko"
@@ -17,12 +17,13 @@ post:
 
 A week after [Copy Fail](/blog/2026-05-01-cve-2026-31431-copy-fail/), researcher Hyunwoo Kim disclosed a second Linux kernel flaw in the same broad area — IPsec ESP and rxrpc — that they have named _Dirty Frag_. The bug lives in the in-place decryption fast paths of `esp4`, `esp6`, and `rxrpc`: when a socket buffer carries paged fragments that are not privately owned by the kernel (e.g. pipe pages attached via `splice(2)`/`sendfile(2)`/`MSG_SPLICE_PAGES`), the receive path decrypts directly over those externally-backed pages, exposing or corrupting plaintext that an unprivileged process still holds a reference to.
 
-Like the previous Copy Fail vulnerability, **Dirty Frag immediately yields root on all major distributions**. Every supported AlmaLinux release is affected. Per Hyunwoo Kim's [public disclosure on oss-security](https://www.openwall.com/lists/oss-security/2026/05/07/8) (2026-05-07), the responsible-disclosure embargo was broken before distributions could coordinate, so **no CVE identifiers have been allocated** for either of the two bugs that make up Dirty Frag, and a working exploit is now publicly available.
+Like the previous Copy Fail vulnerability, **Dirty Frag immediately yields root on all major distributions**. Every supported AlmaLinux release is affected. The flaw is now tracked as [CVE-2026-43284](https://nvd.nist.gov/vuln/detail/CVE-2026-43284). Per Hyunwoo Kim's [public disclosure on oss-security](https://www.openwall.com/lists/oss-security/2026/05/07/8) (2026-05-07), the responsible-disclosure embargo was broken before distributions could coordinate, and a working exploit is publicly available.
 
 If you run AlmaLinux on a multi-tenant host, container build farm, CI runner, or any system where untrusted users can get a shell, this one matters — and with public exploit code in the wild, it matters today.
 
 More information about the vulnerability:
 
+- NVD entry: <https://nvd.nist.gov/vuln/detail/CVE-2026-43284>
 - Public disclosure on oss-security: <https://www.openwall.com/lists/oss-security/2026/05/07/8>
 - Researcher write-up: <https://dirtyfrag.io>
 - Upstream fix for ESP: <https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4>
@@ -126,3 +127,7 @@ Thanks to the AlmaLinux core team for turning around patched builds for every su
 ## Stay informed
 
 Remaining aware of these vulnerabilities and acting quickly can keep your system and data safe. Follow the AlmaLinux Blog, join the [Mattermost Community Chat](https://chat.almalinux.org/), and subscribe to [Announce](https://lists.almalinux.org/mailman3/lists/announce.lists.almalinux.org/) and [Security Mailing List](https://lists.almalinux.org/mailman3/lists/security.lists.almalinux.org/) to stay informed and updated. We will update this post when the patched kernels move from testing to production.
+
+## Changelog
+
+- **2026-05-08 08:28 UTC** — CVE-2026-43284 has been allocated for Dirty Frag.

--- a/layouts/partials/common/nav.html
+++ b/layouts/partials/common/nav.html
@@ -283,7 +283,9 @@
       >
       patched kernels released! &nbsp;|&nbsp;
       <i class="bi bi-shield-exclamation"></i>
-      <a href="{{ "/blog/2026-05-07-dirty-frag/" | relLangURL }}">Dirty Frag</a>
+      <a href="{{ "/blog/2026-05-07-dirty-frag/" | relLangURL }}"
+        >Dirty Frag (CVE-2026-43284)</a
+      >
       patched kernels are in testing!
     </div>
   </div>


### PR DESCRIPTION
## Summary

- CVE-2026-43284 has been allocated for Dirty Frag.
- Updates the blog post title, the announcement paragraph, and the references list to cite the CVE (replacing the earlier "no CVE allocated" wording).
- Adds an NVD link to the references list.
- Adds a Changelog section to the post matching the format used in the Copy Fail post.
- Updates the MOTD banner segment from \`Dirty Frag\` to \`Dirty Frag (CVE-2026-43284)\`.

## Test plan

- [x] Prettier formatted
- [x] \`hugo server\` rendering looks correct (banner + post)
- [x] CVE link in post resolves