### PR TITLE
Track 404 hits in Matomo with requested URL and referrer

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,4 +1,18 @@
 {{ define "main" }}
+  <script>
+    // Must run before footer.html queues trackPageView, so the 404 hit is
+    // recorded with this rewritten title (filterable in Matomo under Page Titles).
+    window._paq = window._paq || [];
+    window._paq.push([
+      "setDocumentTitle",
+      "404/URL = " +
+        encodeURIComponent(
+          document.location.pathname + document.location.search,
+        ) +
+        " /From = " +
+        encodeURIComponent(document.referrer),
+    ]);
+  </script>
   <div class="container">
     <div class="py-5">
       <section


### PR DESCRIPTION
## Summary

Adds Matomo 404 tracking by pushing `setDocumentTitle` into `_paq` from the 404 layout *before* `footer.html` queues `trackPageView`. 404 hits get a title like `404/URL = ... /From = ...`, filterable in Matomo under **Behavior > Page Titles**. Single tracking event per hit — no duplicate Matomo snippet.

Picks up the work from #619 by @Noam-Alum (credited as co-author), and incorporates the simpler approach @codyro identified during review — push only `setDocumentTitle` rather than duplicating the full tracker.

Closes #619.

## Test plan

- [x] `hugo --gc --minify` builds cleanly
- [x] Rendered `public/404.html` contains exactly one `matomo.js` loader
- [x] `setDocumentTitle` push appears in document order before the footer's `trackPageView` push
- [ ] After deploy: visit a non-existent URL and confirm the hit shows up in Matomo under Behavior > Page Titles with the `404/URL = ...` format
