### PR TITLE
Bump Hugo to 0.163.2 and fix reserved i18n key (upgrade enabler)

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: "0.146.7"
+          hugo-version: "0.163.2"
           extended: true
 
       - name: Generate language files

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: "0.146.7"
+          hugo-version: "0.163.2"
           extended: true
 
       - name: Generate language files

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -670,7 +670,7 @@
    "DNS, DHCP, and IP-address-management appliance; ships on AlmaLinux.": "DNS, DHCP, and IP-address-management appliance; ships on AlmaLinux.",
    "Dedicated PR": "Dedicated PR",
    "Defensive patent pool that shields Linux and adjacent open-source projects from patent threats.": "Defensive patent pool that shields Linux and adjacent open-source projects from patent threats.",
-   "Description": "Description",
+   "Product Description": "Product Description",
    "Ethics": "Ethics",
    "Events on community calendar": "Events on community calendar",
    "For companies & organizations contributing funding or resources. Annually renewed; reviewed by the Membership Committee.": "For companies & organizations contributing funding or resources. Annually renewed; reviewed by the Membership Committee.",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -672,7 +672,7 @@
     "DNS, DHCP, and IP-address-management appliance; ships on AlmaLinux.": "DNS, DHCP och IP-adresshanteringsenheter; levereras med AlmaLinux.",
     "Dedicated PR": "Dedikerad PR",
     "Defensive patent pool that shields Linux and adjacent open-source projects from patent threats.": "Defensiv patentpool som skyddar Linux och angränsande öppen källkodsprojekt från patenthot.",
-    "Description": "Beskrivning",
+    "Product Description": "Beskrivning",
     "Ethics": "Etik",
     "Events on community calendar": "Evenemang i gemenskapens kalender",
     "For companies & organizations contributing funding or resources. Annually renewed; reviewed by the Membership Committee.": "För företag och organisationer som bidrar med finansiering eller resurser. Förnyas årligen; granskas av medlemskommittén.",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -672,7 +672,7 @@
     "DNS, DHCP, and IP-address-management appliance; ships on AlmaLinux.": "Пристрій для управління DNS, DHCP та IP-адресами; постачається з AlmaLinux.",
     "Dedicated PR": "Спеціалізований PR",
     "Defensive patent pool that shields Linux and adjacent open-source projects from patent threats.": "Захисний патентний пул, що захищає Linux та суміжні проєкти з відкритим кодом від патентних загроз.",
-    "Description": "Опис",
+    "Product Description": "Опис",
     "Ethics": "Етика",
     "Events on community calendar": "Події в календарі громади",
     "For companies & organizations contributing funding or resources. Annually renewed; reviewed by the Membership Committee.": "Для компаній та організацій, які надають фінансову підтримку або ресурси. Щорічне поновлення; розгляд здійснює Комітет з членства.",

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -672,7 +672,7 @@
     "DNS, DHCP, and IP-address-management appliance; ships on AlmaLinux.": "DNS、DHCP 及 IP 地址管理设备；基于 AlmaLinux。",
     "Dedicated PR": "专属公关",
     "Defensive patent pool that shields Linux and adjacent open-source projects from patent threats.": "防御性专利池，可保护 Linux 及相关开源项目免受专利威胁。",
-    "Description": "说明",
+    "Product Description": "说明",
     "Ethics": "道德规范",
     "Events on community calendar": "社区日历上的活动",
     "For companies & organizations contributing funding or resources. Annually renewed; reviewed by the Membership Committee.": "面向贡献资金或资源的公司及组织。按年续费；由会员委员会审核。",

--- a/layouts/foundation/single.html
+++ b/layouts/foundation/single.html
@@ -416,7 +416,7 @@
             <thead>
               <tr>
                 <th scope="col">{{ i18n "Product" }}</th>
-                <th scope="col">{{ i18n "Description" }}</th>
+                <th scope="col">{{ i18n "Product Description" }}</th>
                 <th scope="col">{{ i18n "Maintainer" }}</th>
               </tr>
             </thead>


### PR DESCRIPTION
Enabler for the Hugo 0.163.2 upgrade. Bumps the Hugo version and renames the reserved go-i18n v2 key `Description` to `Product Description` so the site builds on 0.163. Backward-compatible, so its preview builds green on the base branch's Hugo.

Deprecation cleanup follows in #1070.