### PR TITLE
Make HTML page titles per-page for SEO

### DIFF
--- a/content/p/the-almalinux-os-trademark-usage-policy.md
+++ b/content/p/the-almalinux-os-trademark-usage-policy.md
@@ -1,5 +1,5 @@
 ---
-title: " The AlmaLinux OS trademark usage policy"
+title: "The AlmaLinux OS trademark usage policy"
 type: p
 ---
 

--- a/content/security.md
+++ b/content/security.md
@@ -1,5 +1,5 @@
 ---
-title: "security"
+title: "Security"
 type: security
 ---
 

--- a/layouts/partials/common/head.html
+++ b/layouts/partials/common/head.html
@@ -14,7 +14,13 @@
     content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
     name="viewport" />
   <meta content="ie=edge" http-equiv="X-UA-Compatible" />
-  <title>AlmaLinux OS - Forever-Free Enterprise-Grade Operating System</title>
+  <title>
+    {{- if .IsHome -}}
+      AlmaLinux OS - Forever-Free Enterprise-Grade Operating System
+    {{- else -}}
+      {{ .Title }} | AlmaLinux OS
+    {{- end -}}
+  </title>
   <meta property="og:site_name" content="AlmaLinux OS" />
   <meta
     name="description"


### PR DESCRIPTION
## What

Every page on the site shipped the same hardcoded `<title>` (`AlmaLinux OS - Forever-Free Enterprise-Grade Operating System`), which is bad for SEO and makes it impossible to tell pages apart in analytics.

## Changes

- **Per-page titles** in `layouts/partials/common/head.html`: the homepage (and each language's homepage) keeps the brand tagline; every other page now renders `Page Title | AlmaLinux OS`, pulling from the page's existing `.Title`. Whitespace-trim markers keep the output on a single clean line.
- **Fixed two weak content titles** surfaced while auditing: the Security landing page (linked from the homepage, footer, and nav) was titled `security`, now `Security`; and a stray leading space was trimmed from the trademark policy title.

## Result

Site-wide unique `<title>` count went from 1 to ~298. Verified by building the full site and sampling pages across sections and languages.
