### PR TITLE
Reorder footer social links: Mastodon before X

### DIFF
--- a/layouts/partials/common/footer.html
+++ b/layouts/partials/common/footer.html
@@ -73,10 +73,10 @@
             >
           </li>
           <li><a href="https://www.reddit.com/r/AlmaLinux/">Reddit</a></li>
-          <li><a href="https://x.com/AlmaLinux">X</a></li>
           <li>
             <a href="https://fosstodon.org/@almalinux" rel="me">Mastodon</a>
           </li>
+          <li><a href="https://x.com/AlmaLinux">X</a></li>
           <li><a href="https://www.facebook.com/AlmaLinux/">Facebook</a></li>
           <li>
             <a href="https://www.linkedin.com/company/almalinuxos/">LinkedIn</a>


### PR DESCRIPTION
Reorders the social links in the footer's Community column so Mastodon appears before X.

**Before:** Reddit → X → Mastodon → Facebook → LinkedIn
**After:** Reddit → Mastodon → X → Facebook → LinkedIn

Only the order changes; all URLs (and the `rel="me"` attribute on the Mastodon link) are unchanged. Verified locally with Hugo 0.163.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)