### PR TITLE
Add YouTube to footer social links

### DIFF
--- a/layouts/partials/common/footer.html
+++ b/layouts/partials/common/footer.html
@@ -82,6 +82,9 @@
             <a href="https://www.linkedin.com/company/almalinuxos/">LinkedIn</a>
           </li>
           <li>
+            <a href="https://www.youtube.com/@almalinuxos">YouTube</a>
+          </li>
+          <li>
             <a href="ircs://irc.libera.chat:6697/almalinux">#almalinux IRC</a>
           </li>
         </ul>


### PR DESCRIPTION
Adds a YouTube link to the footer's Community column, placed directly below LinkedIn.

- **Link:** https://www.youtube.com/@almalinuxos
- **Label:** YouTube
- **Position:** …LinkedIn → **YouTube** → #almalinux IRC

Verified locally with Hugo 0.163.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)