### PR TITLE
Update footer social links: reorder, add Bluesky and YouTube

### DIFF
--- a/layouts/partials/common/footer.html
+++ b/layouts/partials/common/footer.html
@@ -73,14 +73,16 @@
             >
           </li>
           <li><a href="https://www.reddit.com/r/AlmaLinux/">Reddit</a></li>
-          <li><a href="https://x.com/AlmaLinux">X</a></li>
           <li>
             <a href="https://fosstodon.org/@almalinux" rel="me">Mastodon</a>
           </li>
+          <li><a href="https://bsky.app/profile/almalinux.org">Bluesky</a></li>
+          <li><a href="https://x.com/AlmaLinux">X</a></li>
           <li><a href="https://www.facebook.com/AlmaLinux/">Facebook</a></li>
           <li>
             <a href="https://www.linkedin.com/company/almalinuxos/">LinkedIn</a>
           </li>
+          <li><a href="https://www.youtube.com/@almalinuxos">YouTube</a></li>
           <li>
             <a href="ircs://irc.libera.chat:6697/almalinux">#almalinux IRC</a>
           </li>


### PR DESCRIPTION
Updates the social links in the footer's Community column.

**Changes**
- Move **Mastodon** above X
- Add **Bluesky** (https://bsky.app/profile/almalinux.org) after Mastodon
- Add **YouTube** (https://www.youtube.com/@almalinuxos) after LinkedIn

**New order:** Reddit → Mastodon → Bluesky → X → Facebook → LinkedIn → YouTube → #almalinux IRC

Existing URLs and the `rel="me"` attribute on the Mastodon link are unchanged. Verified locally with Hugo 0.163.2.

Supersedes #1086 and #1087 (combined here into a single PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)