### PR TITLE
Update GitHub Actions workflows to use latest action versions

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -7,11 +7,11 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
       - run: |
           npm ci
           npx prettier --write .
-      - uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27 # v1.3.2
+      - uses: autofix-ci/action@v1
         with:
           commit-message: "Apply Prettier format"

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     name: Publish Preview to Cloudflare Pages
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
@@ -26,7 +26,7 @@ jobs:
         run: python3 find_missing_i18n_strings.py
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: "0.163.2"
           extended: true
@@ -59,7 +59,7 @@ jobs:
 
       - name: Comment deployment URL on PR
         if: always() && github.event.pull_request.number
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const aliasUrl = `${{ steps.deploy.outputs.pages-deployment-alias-url }}`;

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,13 @@ jobs:
     name: Publish to Cloudflare Pages
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check for missing base language strings
         run: python3 find_missing_i18n_strings.py
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           hugo-version: "0.163.2"
           extended: true
@@ -31,7 +31,7 @@ jobs:
         run: python3 tools/generate_get_almalinux_yaml.py
 
       - name: Create Pull Request for i18n string changes
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           add-paths: i18n/en.json
           title: Automagic i18n string updates

--- a/.github/workflows/update-checksums.yaml
+++ b/.github/workflows/update-checksums.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Create or update PR for checksums
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         if: steps.check-for-changes.outputs.CHANGES_DETECTED == 'true'
         with:
           commit-message: "Update Get AlmaLinux checksums file"


### PR DESCRIPTION
## Summary

Pin GitHub Action versions and upgrade actions to remove Node.js deprecation warnings and improve CI reproducibility.

## Changes

### prettier.yml

* actions/checkout: v5.0.0 → v7
* actions/setup-node: v4.4.0 → v6
* autofix-ci/action: v1.3.2 → v1

### publish-preview.yml

* actions/checkout: v4 → v7
* peaceiris/actions-hugo: v2 → v3
* actions/github-script: v7 → v9

### publish.yml

* actions/checkout: v4 → v7
* peaceiris/actions-hugo: v2 → v3
* peter-evans/create-pull-request: v5 → v8

### update-checksums.yaml

* actions/checkout: v6 → v7
* peter-evans/create-pull-request: v7 → v8