### PR TITLE
Fix Kitten link in FAQ

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -897,7 +897,7 @@
                 data-bs-parent="#accordionFAQ">
                 <div class="accordion-body">
                   {{ i18n "It is the direct upstream for AlmaLinux OS 10 and is the primary point for the AlmaLinux community to engage and influence the future of AlmaLinux OS. Fixes and features land here first and trickle down into AlmaLinux OS as appropriate. It is the integration and collaboration point for AlmaLinux to its upstreams as well, such as CentOS Stream and Fedora. You can read more about it: " }}<a
-                    href="https://wiki.almalinux.org/development/almalinux-os-kitten-10/"
+                    href="https://wiki.almalinux.org/development/almalinux-os-kitten-10.html"
                     >{{ i18n "AlmaLinux Kitten OS" }}.</a
                   >
                 </div>


### PR DESCRIPTION
Fixes #1103
Fix a small typo in "almalinux.org/layouts/index.html" in Kitten link in FAQ. 
The wrong URL "https://wiki.almalinux.org/development/almalinux-os-kitten-10/"
The fixed "https://wiki.almalinux.org/development/almalinux-os-kitten-10.html"